### PR TITLE
Added support for console logging of both server logs and request logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ http:
     port: 8080
     #A secondary port which will serve your administrative content. This should be firewalled off from external access. Check http://localhost:8048/ for what it provides.
     adminPort: 8048
-    #If this block is specified, then the port will be over https
+    #If this block is specified, then the app will run over https (see port property for running in mixed mode)
     ssl:
         #The path to the keystore which will be used to encrypt traffic over SSL on the port.
         keyStore: /etc/pki/tls/jks/keystore.jks
@@ -86,6 +86,8 @@ http:
         keyStorePasswordPath: /path/to/plain/text/file.txt
         #Overrides keyStorePasswordPath if specified, this is the password for the keystore
         keyStorePassword: password
+        #If this is specified as well as http.port and it is different then the app will run in mixed mode (both HTTP and HTTPS)
+        port: 8081
     #If specified, then an access log will be written.
     requestLog:
         file:
@@ -93,17 +95,28 @@ http:
             currentLogFilename: ./server_access_log.txt
 
 logging:
+    #custom log levels - note that in previous versions loggers used to sit under file property, this will throw an exception now if the config remains after updating to this version 
+    loggers:
+        foo: ERROR
+        bar.baz: DEBUG
+    #The default log level - note that in previous versions rootLevel used to sit under file propety, this will throw an exception now if the config remains after updating to this version
+    rootLevel: INFO
     file:
         #The path to the file to write the server log to.
         currentLogFilename: ./server.log
-        #The default log level
-        rootLevel: INFO
         #The threshold over which log statements must be before being logged.
         threshold: ALL
-        #custom log levels
-        loggers:
-            foo: ERROR
-            bar.baz: DEBUG
+        # the timezone to print dates in
+        timeZone: GMT+10
+        # specify a log format for the file log 
+        logFormat: "%-5p [%d{ISO8601,GMT+10}] [%-30thread] %c: %m%n%xEx"
+    console:
+        # the timezone to print dates in (defaults to TimeZone.getDefault())
+        timeZone: GMT+10
+        # the threshold over which log statements must be before being logged.
+        loggingThreshold: ALL
+        # the format for the console log
+        logFormat: "%-5p [%d{ISO8601,GMT+10}] [%-30thread] %c: %m%n%xEx"
 
 #If this block is present, then a jmx server will be started on the given ports. Both are required.
 jmx:

--- a/src/java/grails/plugin/lightweightdeploy/Configuration.java
+++ b/src/java/grails/plugin/lightweightdeploy/Configuration.java
@@ -2,7 +2,7 @@ package grails.plugin.lightweightdeploy;
 
 import grails.plugin.lightweightdeploy.connector.SslConfiguration;
 import grails.plugin.lightweightdeploy.jmx.JmxConfiguration;
-import grails.plugin.lightweightdeploy.logging.FileLoggingConfiguration;
+import grails.plugin.lightweightdeploy.logging.LoggingConfiguration;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
@@ -18,8 +18,8 @@ public class Configuration {
     private Integer port;
     private SslConfiguration sslConfiguration;
     private Integer adminPort;
-    private FileLoggingConfiguration serverLogConfiguration;
-    private FileLoggingConfiguration requestLogConfiguration;
+    private LoggingConfiguration serverLogConfiguration;
+    private LoggingConfiguration requestLogConfiguration;
     private File workDir;
     private JmxConfiguration jmxConfiguration;
 
@@ -43,7 +43,7 @@ public class Configuration {
 
         this.port = (Integer) httpConfig.get("port");
         if (httpConfig.containsKey("ssl")) {
-            Map<String, String> sslConfig = (Map<String, String>) httpConfig.get("ssl");
+            Map<String, ?> sslConfig = (Map<String, ?>) httpConfig.get("ssl");
             this.sslConfiguration = new SslConfiguration(sslConfig);
         }
 
@@ -74,18 +74,13 @@ public class Configuration {
     protected void initRequestLogging(Map<String, ?> config) {
         Map<String, ?> httpConfig = (Map<String, ?>) config.get("http");
         if (httpConfig.containsKey("requestLog")) {
-            Map<String, String> loggingConfig = (Map<String, String>) ((Map<String, ?>) httpConfig.get("requestLog")).get("file");
-            this.requestLogConfiguration = new FileLoggingConfiguration(loggingConfig);
+            requestLogConfiguration = new LoggingConfiguration((Map<String, ?>) httpConfig.get("requestLog"));
         }
     }
 
     protected void initServerLogging(Map<String, ?> config) {
         if (config.containsKey("logging")) {
-            Map<String, ?> loggingConfig = (Map<String, ?>) config.get("logging");
-            if (loggingConfig.containsKey("file")) {
-                Map<String, ?> fileConfig = (Map<String, ?>) loggingConfig.get("file");
-                this.serverLogConfiguration = new FileLoggingConfiguration(fileConfig);
-            }
+            serverLogConfiguration = new LoggingConfiguration((Map<String, ?>) config.get("logging"));
         }
     }
 
@@ -137,11 +132,11 @@ public class Configuration {
         return sslConfiguration;
     }
 
-    public FileLoggingConfiguration getServerLogConfiguration() {
+    public LoggingConfiguration getServerLogConfiguration() {
         return serverLogConfiguration;
     }
 
-    public FileLoggingConfiguration getRequestLogConfiguration() {
+    public LoggingConfiguration getRequestLogConfiguration() {
         return requestLogConfiguration;
     }
 
@@ -152,9 +147,10 @@ public class Configuration {
     @Override
     public String toString() {
         return "Configuration{" +
-               "port=" + port +
-               ", adminPort=" + adminPort +
-               ", ssl=" + isSsl() +
-               '}';
+                "port=" + port +
+                ", adminPort=" + adminPort +
+                ", ssl=" + isSsl() +
+                '}';
     }
+
 }

--- a/src/java/grails/plugin/lightweightdeploy/connector/SslConfiguration.java
+++ b/src/java/grails/plugin/lightweightdeploy/connector/SslConfiguration.java
@@ -14,18 +14,18 @@ public class SslConfiguration {
     private String keyStorePassword;
     private String keyStoreAlias;
 
-    public SslConfiguration(Map<String, String> sslConfig) throws IOException {
-        this.keyStorePath = sslConfig.get("keyStore");
-        this.keyStoreAlias = sslConfig.get("certAlias");
+    public SslConfiguration(Map<String, ?> sslConfig) throws IOException {
+        this.keyStorePath = (String) sslConfig.get("keyStore");
+        this.keyStoreAlias = (String) sslConfig.get("certAlias");
 
         if (sslConfig.containsKey("keyStorePassword")) {
-            this.keyStorePassword = sslConfig.get("keyStorePassword");
+            this.keyStorePassword = (String) sslConfig.get("keyStorePassword");
         } else if (sslConfig.containsKey("keyStorePasswordPath")) {
-            this.keyStorePassword = Files.toString(new File(sslConfig.get("keyStorePasswordPath")), Charsets.US_ASCII);
+            this.keyStorePassword = Files.toString(new File((String) sslConfig.get("keyStorePasswordPath")), Charsets.US_ASCII);
         }
 
         if (sslConfig.containsKey("port")) {
-            this.port = Integer.valueOf(sslConfig.get("port"));
+            this.port = (Integer) sslConfig.get("port");
         }
     }
 

--- a/src/java/grails/plugin/lightweightdeploy/logging/AbstractLoggingConfiguration.java
+++ b/src/java/grails/plugin/lightweightdeploy/logging/AbstractLoggingConfiguration.java
@@ -1,0 +1,62 @@
+package grails.plugin.lightweightdeploy.logging;
+
+import ch.qos.logback.classic.Level;
+import com.google.common.base.Optional;
+
+import java.util.Map;
+import java.util.TimeZone;
+
+public abstract class AbstractLoggingConfiguration {
+
+    private TimeZone timeZone = TimeZone.getDefault();
+    private Level loggingThreshold = Level.ALL;
+    private String logFormat;
+
+    public AbstractLoggingConfiguration(Map<String, ?> config) {
+        if (config.containsKey("timeZone")) {
+            setTimeZone(TimeZone.getTimeZone(config.get("timeZone").toString()));
+        }
+        if (config.containsKey("threshold")) {
+            setLoggingThreshold(Level.toLevel(config.get("threshold").toString()));
+        }
+        if (config.containsKey("logFormat")) {
+            setLogFormat(config.get("logFormat").toString());
+        }
+
+        // handle deprecated logging format
+        if (config.containsKey("rootLevel")) {
+            throw new IllegalArgumentException(
+                    "As of lightweight-deploy versions > 0.9.0 rootLevel is now set one level up under 'logging'.");
+        }
+        if (config.containsKey("loggers")) {
+            throw new IllegalArgumentException(
+                    "As of lightweight-deploy versions > 0.9.0 loggers is now set one level up under 'logging'.");
+        }
+
+    }
+
+    public Level getThreshold() {
+        return loggingThreshold;
+    }
+
+    public TimeZone getTimeZone() {
+        return this.timeZone;
+    }
+
+    public Optional<String> getLogFormat() {
+        return Optional.fromNullable(logFormat);
+    }
+
+    public void setTimeZone(TimeZone timeZone) {
+        this.timeZone = timeZone;
+    }
+
+    public void setLoggingThreshold(Level loggingThreshold) {
+        this.loggingThreshold = loggingThreshold;
+    }
+
+    public void setLogFormat(String logFormat) {
+        this.logFormat = logFormat;
+    }
+
+}

--- a/src/java/grails/plugin/lightweightdeploy/logging/ConsoleLoggingConfiguration.java
+++ b/src/java/grails/plugin/lightweightdeploy/logging/ConsoleLoggingConfiguration.java
@@ -1,0 +1,11 @@
+package grails.plugin.lightweightdeploy.logging;
+
+import java.util.Map;
+
+public class ConsoleLoggingConfiguration extends AbstractLoggingConfiguration {
+
+    public ConsoleLoggingConfiguration(Map<String, ?> config) {
+        super(config);
+    }
+
+}

--- a/src/java/grails/plugin/lightweightdeploy/logging/FileLoggingConfiguration.java
+++ b/src/java/grails/plugin/lightweightdeploy/logging/FileLoggingConfiguration.java
@@ -1,98 +1,33 @@
 package grails.plugin.lightweightdeploy.logging;
 
-import ch.qos.logback.classic.Level;
-import com.google.common.base.Optional;
-
-import java.util.HashMap;
 import java.util.Map;
-import java.util.TimeZone;
 
-public class FileLoggingConfiguration {
+public class FileLoggingConfiguration extends AbstractLoggingConfiguration {
 
     private String logFilePath;
-    private TimeZone logFileTimeZone = TimeZone.getDefault();
-    private Level loggingThreshold = Level.ALL;
-    private Level rootLevel = Level.INFO;
-    private Map<String, Level> loggers = new HashMap<String, Level>();
-    private String logFormat;
 
     public FileLoggingConfiguration(Map<String, ?> config) {
+        super(config);
         this.logFilePath = config.get("currentLogFilename").toString();
-        if (config.containsKey("timeZone")) {
-            setLogFileTimeZone(TimeZone.getTimeZone(config.get("timeZone").toString()));
-        }
-        if (config.containsKey("threshold")) {
-            setLoggingThreshold(Level.toLevel(config.get("threshold").toString()));
-        }
-        if (config.containsKey("rootLevel")) {
-            setRootLevel(Level.toLevel(config.get("rootLevel").toString()));
-        }
-        if (config.containsKey("loggers")) {
-            for (Map.Entry<String, ?> entry : ((Map<String, ?>) config.get("loggers")).entrySet()) {
-                addLogger(entry.getKey(), Level.toLevel(entry.getValue().toString()));
-            }
-        }
-        if (config.containsKey("logFormat")) {
-            setLogFormat(config.get("logFormat").toString());
-        }
     }
 
-    public void addLogger(String packagePath, Level level) {
-        this.loggers.put(packagePath, level);
-    }
-
-    public Level getThreshold() {
-        return loggingThreshold;
-    }
-
-    public TimeZone getTimeZone() {
-        return this.logFileTimeZone;
-    }
-    
     public boolean isArchive() {
         //not currently supported because of bug in logback's file rolling.
         return false;
     }
-    
+
     public String getCurrentLogFilename() {
         return this.logFilePath;
     }
-    
+
     public String getArchivedLogFilenamePattern() {
         //not currently supported because of bug in logback's file rolling.
         return null;
     }
-    
+
     public int getArchivedFileCount() {
         //not currently supported because of bug in logback's file rolling.
         return 0;
     }
 
-    public Optional<String> getLogFormat() {
-        return Optional.fromNullable(logFormat);
-    }
-
-    public Level getRootLevel() {
-        return this.rootLevel;
-    }
-
-    public Map<String, Level> getLoggers() {
-        return loggers;
-    }
-
-    public void setLogFileTimeZone(TimeZone logFileTimeZone) {
-        this.logFileTimeZone = logFileTimeZone;
-    }
-
-    public void setLoggingThreshold(Level loggingThreshold) {
-        this.loggingThreshold = loggingThreshold;
-    }
-
-    public void setRootLevel(Level rootLevel) {
-        this.rootLevel = rootLevel;
-    }
-
-    public void setLogFormat(String logFormat) {
-        this.logFormat = logFormat;
-    }
 }

--- a/src/java/grails/plugin/lightweightdeploy/logging/LoggingConfiguration.java
+++ b/src/java/grails/plugin/lightweightdeploy/logging/LoggingConfiguration.java
@@ -1,0 +1,72 @@
+package grails.plugin.lightweightdeploy.logging;
+
+import ch.qos.logback.classic.Level;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
+
+public class LoggingConfiguration {
+
+    private FileLoggingConfiguration fileConfiguration;
+    private ConsoleLoggingConfiguration consoleConfiguration;
+    private Level rootLevel = Level.INFO;
+    private Map<String, Level> loggers = new HashMap<String, Level>();
+
+    public LoggingConfiguration(Map<String, ?> config) {
+        if (config.containsKey("file")) {
+            Map<String, ?> fileConfig = (Map<String, ?>) config.get("file");
+            this.fileConfiguration = new FileLoggingConfiguration(fileConfig);
+        }
+        if (config.containsKey("console")) {
+            Map<String, ?> consoleConfig = (Map<String, ?>) config.get("console");
+            this.consoleConfiguration = new ConsoleLoggingConfiguration(consoleConfig);
+        }
+        if (config.containsKey("rootLevel")) {
+            rootLevel = Level.toLevel(config.get("rootLevel").toString());
+        }
+        if (config.containsKey("loggers")) {
+            for (Map.Entry<String, ?> entry : ((Map<String, ?>) config.get("loggers")).entrySet()) {
+                loggers.put(entry.getKey(), Level.toLevel(entry.getValue().toString()));
+            }
+        }
+    }
+
+
+    public FileLoggingConfiguration getFileConfiguration() {
+        return fileConfiguration;
+    }
+
+    public ConsoleLoggingConfiguration getConsoleConfiguration() {
+        return consoleConfiguration;
+    }
+
+    public Level getRootLevel() {
+        return rootLevel;
+    }
+
+    public Map<String, Level> getLoggers() {
+        return loggers;
+    }
+
+    public boolean hasFileConfiguration() {
+        return fileConfiguration != null;
+    }
+
+    public boolean hasConsoleConfiguration() {
+        return consoleConfiguration != null;
+    }
+
+    public TimeZone getTimeZone() {
+
+        if (hasConsoleConfiguration()) {
+            return consoleConfiguration.getTimeZone();
+        } else if (hasFileConfiguration()) {
+            return fileConfiguration.getTimeZone();
+        }
+
+        return TimeZone.getDefault();
+
+    }
+
+}

--- a/test/unit/grails/plugin/lightweightdeploy/ConfigurationTest.groovy
+++ b/test/unit/grails/plugin/lightweightdeploy/ConfigurationTest.groovy
@@ -2,9 +2,8 @@ package grails.plugin.lightweightdeploy
 
 import ch.qos.logback.classic.Level
 import org.junit.Test
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertTrue
+
+import static org.junit.Assert.*
 
 public class ConfigurationTest {
 
@@ -47,109 +46,174 @@ public class ConfigurationTest {
     }
 
     @Test
-    void serverLoggingThresholdShouldDefaultToAll() throws IOException {
+    void serverConsoleLoggingThresholdShouldDefaultToAll() throws IOException {
         Map<String, ? extends Object> config = defaultConfig()
-        attachServerLoggingConfig(config).file.remove("threshold")
+        attachServerConsoleLoggingConfig(config).console.remove("threshold")
         Configuration configuration = new Configuration(config)
-        assertEquals(Level.ALL, configuration.serverLogConfiguration.threshold)
+        assertEquals(Level.ALL, configuration.serverLogConfiguration.consoleConfiguration.threshold)
     }
 
     @Test
-    void serverLoggingRootLevelShouldDefaultToInfo() throws IOException {
-        Map<String, ? extends Object> config = defaultConfig()
-        attachServerLoggingConfig(config).file.remove("rootLevel")
-        Configuration configuration = new Configuration(config)
-        assertEquals(Level.INFO, configuration.serverLogConfiguration.rootLevel)
-    }
-
-    @Test
-    void serverLoggingLoggersIsNotRequired() throws IOException {
-        Map<String, ? extends Object> config = defaultConfig()
-        attachServerLoggingConfig(config).file.remove("loggers")
-        Configuration configuration = new Configuration(config)
-        assertEquals(0, configuration.serverLogConfiguration.loggers.size())
-    }
-
-    @Test
-    void serverLoggingLoggersCanBeEmpty() throws IOException {
-        Map<String, ? extends Object> config = defaultConfig()
-        attachServerLoggingConfig(config).file.loggers.clear()
-        Configuration configuration = new Configuration(config)
-        assertEquals(0, configuration.serverLogConfiguration.loggers.size())
-    }
-
-    @Test
-    void ifServerLoggingFileSetInConfigThenFileLoggingShouldBeSetToTrue() throws IOException {
+    void ifServerLoggingConsoleSetInConfigThenFileLoggingShouldBeSetToTrue() throws IOException {
         Map<String, Map<String, Object>> config = defaultConfig()
-        attachServerLoggingConfig(config)
+        attachServerConsoleLoggingConfig(config)
         Configuration configuration = new Configuration(config)
         assertTrue(configuration.isServerLoggingEnabled())
     }
 
     @Test
-    void serverLoggingThresholdShouldBeSetToValueInFile() throws IOException {
+    void serverConsoleLoggingThresholdShouldBeSetToValueInFile() throws IOException {
         Map<String, Map<String, Object>> config = defaultConfig()
-        attachServerLoggingConfig(config)
+        attachServerConsoleLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals(Level.DEBUG, configuration.serverLogConfiguration.threshold)
+        assertEquals(Level.DEBUG, configuration.serverLogConfiguration.consoleConfiguration.threshold)
     }
 
     @Test
-    void serverLoggingRootLevelShouldBeSetToValueInFile() throws IOException {
+    void serverConsoleLoggingTimezoneShouldDefaultToLocal() throws IOException {
         Map<String, Map<String, Object>> config = defaultConfig()
-        attachServerLoggingConfig(config)
+        attachServerConsoleLoggingConfig(config)
+        config.logging.console.remove("timeZone")
+        Configuration configuration = new Configuration(config)
+        assertEquals(TimeZone.default, configuration.serverLogConfiguration.consoleConfiguration.timeZone)
+    }
+
+    @Test
+    void serverConsoleLoggingTimezoneShouldBeSetToValueInFile() throws IOException {
+        Map<String, Map<String, Object>> config = defaultConfig()
+        attachServerConsoleLoggingConfig(config)
+        Configuration configuration = new Configuration(config)
+        assertEquals(TimeZone.getTimeZone("GMT+10"), configuration.serverLogConfiguration.consoleConfiguration.timeZone)
+    }
+
+    @Test
+    void serverConsoleLoggingFormatShouldBeSetToValueInFile() throws IOException {
+        Map<String, Map<String, Object>> config = defaultConfig()
+        attachServerConsoleLoggingConfig(config)
+        Configuration configuration = new Configuration(config)
+        assertEquals("[%d{ISO8601}] %m%n", configuration.serverLogConfiguration.consoleConfiguration.logFormat.get())
+    }
+
+    @Test
+    void serverFileLoggingThresholdShouldDefaultToAll() throws IOException {
+        Map<String, ? extends Object> config = defaultConfig()
+        attachServerFileLoggingConfig(config).file.remove("threshold")
+        Configuration configuration = new Configuration(config)
+        assertEquals(Level.ALL, configuration.serverLogConfiguration.fileConfiguration.threshold)
+    }
+
+    @Test
+    void serverFileLoggingRootLevelShouldDefaultToInfo() throws IOException {
+        Map<String, ? extends Object> config = defaultConfig()
+        attachServerFileLoggingConfig(config).remove("rootLevel")
+        Configuration configuration = new Configuration(config)
+        assertEquals(Level.INFO, configuration.serverLogConfiguration.rootLevel)
+    }
+
+    @Test
+    void serverFileLoggingLoggersIsNotRequired() throws IOException {
+        Map<String, ? extends Object> config = defaultConfig()
+        attachServerFileLoggingConfig(config).remove("loggers")
+        Configuration configuration = new Configuration(config)
+        assertEquals(0, configuration.serverLogConfiguration.loggers.size())
+    }
+
+    @Test
+    void serverFileLoggingLoggersCanBeEmpty() throws IOException {
+        Map<String, ? extends Object> config = defaultConfig()
+        attachServerFileLoggingConfig(config).loggers.clear()
+        Configuration configuration = new Configuration(config)
+        assertEquals(0, configuration.serverLogConfiguration.loggers.size())
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void serverFileLoggingShouldNotAcceptLoggersInsideFileConfiguration() {
+        Map<String, ? extends Object> config = defaultConfig()
+        attachServerFileLoggingConfig(config)
+        config.logging.file.put("loggers", config.logging.loggers)
+        new Configuration(config)
+    }
+
+    @Test(expected = IllegalArgumentException)
+    void serverFileLoggingShouldNotAcceptRootLevelInsideFileConfiguration() {
+        Map<String, ? extends Object> config = defaultConfig()
+        attachServerFileLoggingConfig(config)
+        config.logging.file.put("rootLevel", config.logging.rootLevel)
+        new Configuration(config)
+    }
+
+    @Test
+    void ifServerLoggingFileSetInConfigThenFileLoggingShouldBeSetToTrue() throws IOException {
+        Map<String, Map<String, Object>> config = defaultConfig()
+        attachServerFileLoggingConfig(config)
+        Configuration configuration = new Configuration(config)
+        assertTrue(configuration.isServerLoggingEnabled())
+    }
+
+    @Test
+    void serverFileLoggingThresholdShouldBeSetToValueInFile() throws IOException {
+        Map<String, Map<String, Object>> config = defaultConfig()
+        attachServerFileLoggingConfig(config)
+        Configuration configuration = new Configuration(config)
+        assertEquals(Level.DEBUG, configuration.serverLogConfiguration.fileConfiguration.threshold)
+    }
+
+    @Test
+    void serverFileLoggingRootLevelShouldBeSetToValueInFile() throws IOException {
+        Map<String, Map<String, Object>> config = defaultConfig()
+        attachServerFileLoggingConfig(config)
         Configuration configuration = new Configuration(config)
         assertEquals(Level.WARN, configuration.serverLogConfiguration.rootLevel)
     }
 
     @Test
-    void serverLoggingLoggersShouldBeSetToValueInFile() throws IOException {
+    void serverFileLoggingLoggersShouldBeSetToValueInFile() throws IOException {
         Map<String, Map<String, Object>> config = defaultConfig()
-        attachServerLoggingConfig(config)
+        attachServerFileLoggingConfig(config)
         Configuration configuration = new Configuration(config)
         assertEquals(Level.INFO, configuration.serverLogConfiguration.loggers."foo")
         assertEquals(Level.ERROR, configuration.serverLogConfiguration.loggers."bar.baz")
     }
 
     @Test
-    void serverLoggingFileShouldBeSetToValueInFile() throws IOException {
+    void serverFileLoggingFileShouldBeSetToValueInFile() throws IOException {
         Map<String, Map<String, Object>> config = defaultConfig()
-        attachServerLoggingConfig(config)
+        attachServerFileLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals("/app/logs/server.log", configuration.serverLogConfiguration.currentLogFilename)
+        assertEquals("/app/logs/server.log", configuration.serverLogConfiguration.fileConfiguration.currentLogFilename)
     }
 
     @Test
-    void serverLoggingTimezoneShouldDefaultToLocal() throws IOException {
+    void serverFileLoggingTimezoneShouldDefaultToLocal() throws IOException {
         Map<String, Map<String, Object>> config = defaultConfig()
-        attachServerLoggingConfig(config)
+        attachServerFileLoggingConfig(config)
         config.logging.file.remove("timeZone")
         Configuration configuration = new Configuration(config)
-        assertEquals(TimeZone.default, configuration.serverLogConfiguration.timeZone)
+        assertEquals(TimeZone.default, configuration.serverLogConfiguration.fileConfiguration.timeZone)
     }
 
     @Test
-    void serverLoggingTimezoneShouldBeSetToValueInFile() throws IOException {
+    void serverFileLoggingTimezoneShouldBeSetToValueInFile() throws IOException {
         Map<String, Map<String, Object>> config = defaultConfig()
-        attachServerLoggingConfig(config)
+        attachServerFileLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals(TimeZone.getTimeZone("GMT+10"), configuration.serverLogConfiguration.timeZone)
+        assertEquals(TimeZone.getTimeZone("GMT+10"), configuration.serverLogConfiguration.fileConfiguration.timeZone)
     }
 
     @Test
-    void serverLoggingFormatShouldBeSetToValueInFile() throws IOException {
+    void serverFileLoggingFormatShouldBeSetToValueInFile() throws IOException {
         Map<String, Map<String, Object>> config = defaultConfig()
-        attachServerLoggingConfig(config)
+        attachServerFileLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals("[%d{ISO8601}] %m%n", configuration.serverLogConfiguration.logFormat.get())
+        assertEquals("[%d{ISO8601}] %m%n", configuration.serverLogConfiguration.fileConfiguration.logFormat.get())
     }
-    
+
     @Test
     void requestLoggingThresholdShouldDefaultToAll() throws IOException {
         Map<String, ? extends Object> config = defaultConfig()
         attachRequestLoggingConfig(config).file.remove("threshold")
         Configuration configuration = new Configuration(config)
-        assertEquals(Level.ALL, configuration.requestLogConfiguration.threshold)
+        assertEquals(Level.ALL, configuration.requestLogConfiguration.fileConfiguration.threshold)
     }
 
     @Test
@@ -165,7 +229,7 @@ public class ConfigurationTest {
         Map<String, Map<String, Object>> config = defaultConfig()
         attachRequestLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals(Level.ALL, configuration.requestLogConfiguration.threshold)
+        assertEquals(Level.ALL, configuration.requestLogConfiguration.fileConfiguration.threshold)
     }
 
     @Test
@@ -173,7 +237,7 @@ public class ConfigurationTest {
         Map<String, Map<String, Object>> config = defaultConfig()
         attachRequestLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals("/app/logs/request.log", configuration.requestLogConfiguration.currentLogFilename)
+        assertEquals("/app/logs/request.log", configuration.requestLogConfiguration.fileConfiguration.currentLogFilename)
     }
 
     @Test
@@ -206,7 +270,7 @@ public class ConfigurationTest {
         Configuration configuration = new Configuration(config)
         assertEquals(new File("/apps/test"), configuration.getWorkDir())
     }
-    
+
     @Test
     void jmxShouldBeDisabledIfConfigOmitted() {
         Map<String, ? extends Object> config = defaultConfig()
@@ -246,35 +310,53 @@ public class ConfigurationTest {
     protected Map<String, Map<String, Object>> defaultConfig() {
         [http: [port: 1234,
                 ssl: [keyStore: "/etc/pki/tls/jks/test.jks",
-                      keyStorePassword: "password",
-                      certAlias: "app.domain.com"]]]
+                        keyStorePassword: "password",
+                        certAlias: "app.domain.com"]]]
     }
 
     protected def attachJmxConfig(def config) {
         config.jmx = [serverPort: 1234,
-                      registryPort: 2345]
+                registryPort: 2345]
         config.jmx
     }
 
     protected def attachRequestLoggingConfig(def config) {
-        config.http.requestLog = [file: [threshold: Level.ALL.levelStr,
-                                         currentLogFilename: "/app/logs/request.log",
-                                         timeZone: "GMT+10"]]
+        config.http.requestLog = [
+                file: [
+                        threshold: Level.ALL.levelStr,
+                        currentLogFilename: "/app/logs/request.log",
+                        timeZone: "GMT+10"
+                ]]
         config.http.requestLog
     }
 
-    protected Map<String, Object> attachServerLoggingConfig(Map<String, Map<String, Object>> config) {
+    protected Map<String, Object> attachServerFileLoggingConfig(Map<String, Map<String, Object>> config) {
         config.logging = [
-                file: [
-                    threshold: Level.DEBUG.levelStr,
-                    rootLevel: Level.WARN.levelStr,
-                    loggers: [
+                rootLevel: Level.WARN.levelStr,
+                loggers: [
                         "foo": Level.INFO.levelStr,
                         "bar.baz": Level.ERROR.levelStr
-                    ],
-                    currentLogFilename: "/app/logs/server.log",
-                    timeZone: "GMT+10",
-                    logFormat: "[%d{ISO8601}] %m%n"]]
+                ],
+                file: [
+                        threshold: Level.DEBUG.levelStr,
+                        currentLogFilename: "/app/logs/server.log",
+                        timeZone: "GMT+10",
+                        logFormat: "[%d{ISO8601}] %m%n"]]
         config.logging
     }
+
+    protected Map<String, Object> attachServerConsoleLoggingConfig(Map<String, Map<String, Object>> config) {
+        config.logging = [
+                rootLevel: Level.WARN.levelStr,
+                loggers: [
+                        "foo": Level.INFO.levelStr,
+                        "bar.baz": Level.ERROR.levelStr
+                ],
+                console: [
+                        threshold: Level.DEBUG.levelStr,
+                        timeZone: "GMT+10",
+                        logFormat: "[%d{ISO8601}] %m%n"]]
+        config.logging
+    }
+
 }

--- a/test/unit/grails/plugin/lightweightdeploy/connector/ExternalConnectorFactoryTest.groovy
+++ b/test/unit/grails/plugin/lightweightdeploy/connector/ExternalConnectorFactoryTest.groovy
@@ -95,7 +95,7 @@ class ExternalConnectorFactoryTest {
                     keyStorePassword: "password",
                     certAlias: "app.domain.com"]
             if (isMixedMode) {
-                map.http.ssl.put("port", "1235")
+                map.http.ssl.put("port", 1235)
             }
         }
         new Configuration(map)


### PR DESCRIPTION
Does what it says on the packet. 

Note that this update is not backwards compatible with previous versions of this plugin. If rootLevel or loggers were previously set under file properties in the yaml config file they'll need to be moved one level up. 
