### PR TITLE
Nicer defaults for server, connector, and handlers

### DIFF
--- a/src/java/grails/plugin/lightweightdeploy/Launcher.java
+++ b/src/java/grails/plugin/lightweightdeploy/Launcher.java
@@ -47,10 +47,15 @@ public class Launcher {
     /**
      * Start the server.
      */
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
         verifyArgs(args);
         final Launcher launcher = new Launcher(args[0]);
-        launcher.start();
+        try {
+            launcher.start();
+        } catch (Exception e) {
+            System.exit(1);
+            throw e;
+        }
     }
 
     public Launcher(String configYmlPath) throws IOException {
@@ -86,7 +91,7 @@ public class Launcher {
         }
     }
 
-    protected void start() throws IOException {
+    protected void start() throws Exception {
         War war = new War(this.configuration.getWorkDir());
 
         Server server = configureJetty(war);
@@ -157,13 +162,13 @@ public class Launcher {
         return createInternalContext(server);
     }
 
-    protected void startJetty(Server server) {
+    protected void startJetty(Server server) throws Exception {
         try {
             server.start();
             logger.info("Startup complete. Server running on " + this.configuration.getPort());
         } catch (Exception e) {
             logger.error("Error starting jetty. Exiting JVM.", e);
-            System.exit(1);
+            server.stop();
         }
     }
 

--- a/src/java/grails/plugin/lightweightdeploy/Launcher.java
+++ b/src/java/grails/plugin/lightweightdeploy/Launcher.java
@@ -3,6 +3,7 @@ package grails.plugin.lightweightdeploy;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.codahale.metrics.health.jvm.ThreadDeadlockHealthCheck;
+import com.codahale.metrics.jetty8.InstrumentedHandler;
 import com.codahale.metrics.jetty8.InstrumentedQueuedThreadPool;
 import com.codahale.metrics.servlets.AdminServlet;
 import grails.plugin.lightweightdeploy.connector.ExternalConnectorFactory;
@@ -186,7 +187,7 @@ public class Launcher {
 
         configureExternalServlets(handler);
 
-        return handler;
+        return new InstrumentedHandler(metricsRegistry, handler);
     }
 
     private static String[] getConnectorNames(Server server) {

--- a/src/java/grails/plugin/lightweightdeploy/connector/ExternalConnectorFactory.java
+++ b/src/java/grails/plugin/lightweightdeploy/connector/ExternalConnectorFactory.java
@@ -60,6 +60,12 @@ public class ExternalConnectorFactory extends AbstractConnectorFactory {
         connector.setName(EXTERNAL_HTTP_CONNECTOR_NAME);
         connector.setUseDirectBuffers(true);
 
+        // Use X-Forwarded-For header for origin IP
+        connector.setForwarded(true);
+
+        // allow socket reuse
+        connector.setReuseAddress(true);
+
         return connector;
     }
 


### PR DESCRIPTION
Tweaks some of the defaults to be a bit nicer. The core changes are as follows:
- GZip supprt for various text response MIME types.
- Instrumented external handler for more metrics.
- Capped and instrumented default thread pool.
- Removal of server HTTP headers that pose a "security" issue
- Allow rapid restarts with socket reuse
- Grace period during shutdown to give requets a chance to complete
- Use X-Forwarded-For header for remote IP
