### PR TITLE
Add extra Javascript MIME type.

### DIFF
--- a/src/java/grails/plugin/lightweightdeploy/Launcher.java
+++ b/src/java/grails/plugin/lightweightdeploy/Launcher.java
@@ -207,7 +207,7 @@ public class Launcher {
         gzipHandler.setMinGzipSize(256);
         gzipHandler.setMimeTypes(ImmutableSet.of(
                 "application/json", "application/xml", "text/html", "text/plain", "application/javascript",
-                "text/javascript", "text/css", "text/xml"
+                "application/x-javascript", "text/javascript", "text/css", "text/xml"
         ));
         gzipHandler.setVary(HttpHeaders.ACCEPT_ENCODING);
 


### PR DESCRIPTION
Seems Grails still generats x-javascript somewhere so we should compress
that as well.
