### PR TITLE
Add extended log attributes to access log.

### DIFF
--- a/src/java/grails/plugin/lightweightdeploy/logging/AsyncRequestLog.java
+++ b/src/java/grails/plugin/lightweightdeploy/logging/AsyncRequestLog.java
@@ -172,6 +172,24 @@ public class AsyncRequestLog extends AbstractLifeCycle implements RequestLog {
             buf.append(" -");
         }
 
+        String referer = request.getHeader(HttpHeaders.REFERER);
+        if (referer == null) {
+            buf.append("\"-\" ");
+        } else {
+            buf.append('"');
+            buf.append(referer);
+            buf.append("\" ");
+        }
+
+        String agent = request.getHeader(HttpHeaders.USER_AGENT);
+        if (agent == null) {
+            buf.append("\"-\" ");
+        } else {
+            buf.append('"');
+            buf.append(agent);
+            buf.append('"');
+        }
+
         final long now = clock.getTime();
         final long dispatchTime = request.getDispatchTime();
 

--- a/test/unit/grails/plugin/lightweightdeploy/ExternalContextTest.groovy
+++ b/test/unit/grails/plugin/lightweightdeploy/ExternalContextTest.groovy
@@ -18,7 +18,7 @@ class ExternalContextTest {
     @Test
     void defaultsDescriptorShouldBeSet() {
         def tmpDir = System.getProperty("java.io.tmpdir");
-        assertTrue(externalContext.defaultsDescriptor.matches(tmpDir + "webdefault[0-9]+?\\.war"))
+        assertTrue("Failed to match " + externalContext.defaultsDescriptor, externalContext.defaultsDescriptor.matches(tmpDir + "webdefault[0-9]+?\\.war"))
     }
 
     @Test


### PR DESCRIPTION
Includes User-Agent and Referer header values in access log.
