### PR TITLE
Support configuring the session ID worker name.

### DIFF
--- a/src/java/grails/plugin/lightweightdeploy/Launcher.java
+++ b/src/java/grails/plugin/lightweightdeploy/Launcher.java
@@ -10,9 +10,11 @@ import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 import com.codahale.metrics.servlets.AdminServlet;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import grails.plugin.lightweightdeploy.connector.ExternalConnectorFactory;
 import grails.plugin.lightweightdeploy.connector.InternalConnectorFactory;
+import grails.plugin.lightweightdeploy.connector.SessionsConfiguration;
 import grails.plugin.lightweightdeploy.jmx.JmxServer;
 import grails.plugin.lightweightdeploy.logging.RequestLoggingFactory;
 import grails.plugin.lightweightdeploy.logging.ServerLoggingFactory;
@@ -20,8 +22,10 @@ import org.eclipse.jetty.http.HttpHeaders;
 import org.eclipse.jetty.server.AbstractConnector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.SessionManager;
 import org.eclipse.jetty.server.handler.GzipHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
+import org.eclipse.jetty.server.session.HashSessionIdManager;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlets.GzipFilter;
@@ -187,7 +191,6 @@ public class Launcher {
     }
 
     protected Handler createInternalContext(Server server) {
-
         final ServletContextHandler handler = new InternalContext(getHealthCheckRegistry(), getMetricsRegistry());
 
         //bind this context to the external connector
@@ -204,6 +207,20 @@ public class Launcher {
 
     protected Handler createExternalContext(Server server, String webAppRoot) throws IOException {
         final WebAppContext handler = new ExternalContext(webAppRoot, getMetricsRegistry(), getHealthCheckRegistry());
+
+        // Enable sessions support if required
+        final SessionsConfiguration sessionsConfiguration = configuration.getHttpConfiguration().getSessionsConfiguration();
+        if (sessionsConfiguration.isEnabled()) {
+            final HashSessionIdManager idManager = new HashSessionIdManager();
+            if (!Strings.isNullOrEmpty(sessionsConfiguration.getWorkerName())) {
+                idManager.setWorkerName(sessionsConfiguration.getWorkerName());
+            }
+
+            // Assumes ExternalContext extends WebAppContext which configures sessions by default
+            handler.getSessionHandler().getSessionManager().setSessionIdManager(idManager);
+        } else {
+            handler.setSessionHandler(null);
+        }
 
         //bind this context to the external connector
         handler.setConnectorNames(getConnectorNames(server));

--- a/src/java/grails/plugin/lightweightdeploy/connector/HttpConfiguration.java
+++ b/src/java/grails/plugin/lightweightdeploy/connector/HttpConfiguration.java
@@ -48,6 +48,8 @@ public class HttpConfiguration {
 
     private int lowResourcesMaxIdleTime = 0;
 
+    private SessionsConfiguration sessionsConfiguration = new SessionsConfiguration();
+
     private SslConfiguration sslConfiguration;
 
     public HttpConfiguration(final Map<String, ?> httpConfig) throws IOException {
@@ -68,6 +70,10 @@ public class HttpConfiguration {
         this.reuseAddress = Objects.firstNonNull((Boolean) httpConfig.get("reuseAddress"), reuseAddress);
         this.soLingerTime = (Integer) httpConfig.get("soLingerTime");
         this.lowResourcesMaxIdleTime = Objects.firstNonNull((Integer) httpConfig.get("lowResourcesMaxIdleTime"), lowResourcesMaxIdleTime);
+
+        if (httpConfig.containsKey("sessions")) {
+            this.sessionsConfiguration = new SessionsConfiguration((Map<String, ?>) httpConfig.get("sessions"));
+        }
 
         if (httpConfig.containsKey("ssl")) {
             Map<String, ?> sslConfig = (Map<String, ?>) httpConfig.get("ssl");
@@ -153,6 +159,10 @@ public class HttpConfiguration {
 
     public boolean isSsl() {
         return (getSslConfiguration() != null);
+    }
+
+    public SessionsConfiguration getSessionsConfiguration() {
+        return sessionsConfiguration;
     }
 
 }

--- a/src/java/grails/plugin/lightweightdeploy/connector/SessionsConfiguration.java
+++ b/src/java/grails/plugin/lightweightdeploy/connector/SessionsConfiguration.java
@@ -1,0 +1,44 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2014, Wotif.com. All rights reserved.
+//
+// This is unpublished proprietary source code of Wotif.com.
+// The copyright notice above does not evidence any actual or intended
+// publication of such source code.
+//
+////////////////////////////////////////////////////////////////////////////////
+package grails.plugin.lightweightdeploy.connector;
+
+import com.google.common.base.Objects;
+
+import java.util.Map;
+
+public class SessionsConfiguration {
+
+    private final boolean enabled;
+
+    private final String workerName;
+
+    public SessionsConfiguration() {
+        this(true, "");
+    }
+
+    public SessionsConfiguration(final Map<String, ?> config) {
+        this(Objects.firstNonNull((Boolean) config.get("enabled"), true),
+                Objects.firstNonNull((String) config.get("workerName"), ""));
+    }
+
+    private SessionsConfiguration(final boolean enabled, final String workerName) {
+        this.enabled = enabled;
+        this.workerName = workerName;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getWorkerName() {
+        return workerName;
+    }
+
+}

--- a/test/unit/grails/plugin/lightweightdeploy/connector/HttpConfigurationTest.groovy
+++ b/test/unit/grails/plugin/lightweightdeploy/connector/HttpConfigurationTest.groovy
@@ -72,6 +72,23 @@ public class HttpConfigurationTest {
         assertEquals(10000, configuration.maxThreads)
     }
 
+    @Test
+    void sessionsEnabledByDefault() {
+        Map<String, ? extends Object> config = defaultConfig()
+        HttpConfiguration configuration = new HttpConfiguration(config)
+        assertTrue(configuration.sessionsConfiguration.enabled);
+        assertEquals("", configuration.sessionsConfiguration.workerName);
+    }
+
+    @Test
+    void sessionsWorkerNameShouldBeSetIfPresent() {
+        Map<String, ? extends Object> config = defaultConfig()
+        config.sessions = [enabled: true, workerName: "workerName"];
+        HttpConfiguration configuration = new HttpConfiguration(config)
+        assertTrue(configuration.sessionsConfiguration.enabled);
+        assertEquals("workerName", configuration.sessionsConfiguration.workerName);
+    }
+
     protected Map<String, Map<String, Object>> defaultConfig() {
         [port: 1234,
                 ssl: [keyStore: "/etc/pki/tls/jks/test.jks",


### PR DESCRIPTION
This is to support running behind a mod_ajp proxy in Apache.

To use add a new block to your config.yaml that looks like this:

``` yaml
http:
    sessions:
        enabled: true
        workerName: worker1
```
