### PR TITLE
Enhance request correlation filter.

### DIFF
--- a/src/java/grails/plugin/lightweightdeploy/servlets/RequestAndAccessCorrelationFilter.java
+++ b/src/java/grails/plugin/lightweightdeploy/servlets/RequestAndAccessCorrelationFilter.java
@@ -44,6 +44,7 @@ public class RequestAndAccessCorrelationFilter implements Filter {
 
             MDC.put(REQUEST_ID, requestId);
             request.setAttribute(REQUEST_ID, requestId);
+            // Response headers must be set prior to handling request as Transfer-Encoding is "chunked"
             sendRequestId(siteLocal, (HttpServletResponse) response, requestId);
         }
 

--- a/src/java/grails/plugin/lightweightdeploy/servlets/RequestAndAccessCorrelationFilter.java
+++ b/src/java/grails/plugin/lightweightdeploy/servlets/RequestAndAccessCorrelationFilter.java
@@ -1,22 +1,24 @@
 package grails.plugin.lightweightdeploy.servlets;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Strings;
+import com.google.common.collect.Iterators;
+import com.google.common.net.InetAddresses;
 import org.slf4j.MDC;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Iterator;
 import java.util.regex.Pattern;
 
 public class RequestAndAccessCorrelationFilter implements Filter {
 
     @VisibleForTesting
-    static final String START_TIME = RequestAndAccessCorrelationFilter.class.getName() + ".startTime";
-
-    @VisibleForTesting
     static final String X_OPAQUE_ID = "X-Opaque-ID";
+    @VisibleForTesting
+    static final String REQUEST_ID = "requestId";
 
     private static final Pattern NEW_LINES = Pattern.compile("[\r\n]");
 
@@ -34,33 +36,40 @@ public class RequestAndAccessCorrelationFilter implements Filter {
 
     @Override
     public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
-            throws IOException,
-            ServletException {
-        request.setAttribute(START_TIME, System.currentTimeMillis());
+            throws IOException, ServletException {
+        if (request instanceof HttpServletRequest && response instanceof HttpServletResponse) {
+            final boolean siteLocal = isSiteLocalRequest(request);
 
-        if (request instanceof HttpServletRequest) {
-            final HttpServletRequest httpRequest = (HttpServletRequest) request;
-            final HttpServletResponse httpResponse = (HttpServletResponse) response;
+            final String requestId = buildRequestId(siteLocal, (HttpServletRequest) request);
 
-            String requestId = httpRequest.getHeader(X_OPAQUE_ID);
-            if (Strings.isNullOrEmpty(requestId)) {
-                requestId = idGenerator.generate();
-            } else {
-                // Protect against HTTP response splitting.
-                requestId = NEW_LINES.matcher(requestId).replaceAll("");
-            }
-
-            MDC.put("requestId", requestId);
-            request.setAttribute("requestId", requestId);
-
-            httpResponse.setHeader(X_OPAQUE_ID, requestId);
+            MDC.put(REQUEST_ID, requestId);
+            request.setAttribute(REQUEST_ID, requestId);
+            sendRequestId(siteLocal, (HttpServletResponse) response, requestId);
         }
 
         chain.doFilter(request, response);
+    }
 
-        long startTime = (Long) request.getAttribute(START_TIME);
-        final long duration = System.currentTimeMillis() - startTime;
-        MDC.put("timeTaken", String.valueOf(duration));
+    private boolean isSiteLocalRequest(final ServletRequest request) {
+        InetAddress inetAddress = InetAddresses.forString(request.getRemoteAddr());
+        return inetAddress.isLoopbackAddress() || inetAddress.isSiteLocalAddress();
+    }
+
+    // TODO: Move this to common request handler library
+    private String buildRequestId(final boolean siteLocal, final HttpServletRequest httpRequest) {
+        final Iterator<String> headers = Iterators.forEnumeration(httpRequest.getHeaderNames());
+        if (siteLocal && Iterators.contains(headers, X_OPAQUE_ID)) {
+            final String requestId = httpRequest.getHeader(X_OPAQUE_ID);
+            return NEW_LINES.matcher(requestId).replaceAll("");
+        }
+        return idGenerator.generate();
+    }
+
+    // TODO: Move this to common request handler library
+    private void sendRequestId(final boolean siteLocal, final HttpServletResponse httpResponse, final String requestId) {
+        if (siteLocal) {
+            httpResponse.setHeader(X_OPAQUE_ID, requestId);
+        }
     }
 
 }


### PR DESCRIPTION
- Set header earlier so it works even in chunked responses.
- Ensure that tracing header is only accepted from local networks.
- Drop timeTaken as Jetty tracks that.
