### PR TITLE
Handle broken X-Forwarded-For case.

### DIFF
--- a/src/java/grails/plugin/lightweightdeploy/servlets/RequestAndAccessCorrelationFilter.java
+++ b/src/java/grails/plugin/lightweightdeploy/servlets/RequestAndAccessCorrelationFilter.java
@@ -52,8 +52,13 @@ public class RequestAndAccessCorrelationFilter implements Filter {
     }
 
     private boolean isSiteLocalRequest(final ServletRequest request) {
-        InetAddress inetAddress = InetAddresses.forString(request.getRemoteAddr());
-        return inetAddress.isLoopbackAddress() || inetAddress.isSiteLocalAddress();
+        // If the address is invalid it's probably from the Internet
+        try {
+            InetAddress inetAddress = InetAddresses.forString(request.getRemoteAddr());
+            return inetAddress.isLoopbackAddress() || inetAddress.isSiteLocalAddress();
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     // TODO: Move this to common request handler library


### PR DESCRIPTION
When the remote address is invalid in some way, ignore and assume
it's a public address.
