### PR TITLE
Expand logging options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ http:
     adminPort: 8048
 
 logging:
-    file:
+    appenders:
+      - type: file
         currentLogFilename: ./server.log
         rootLevel: INFO
 ```
@@ -94,7 +95,9 @@ http:
         port: 8081
     #If specified, then an access log will be written.
     requestLog:
-        file:
+        appenders:
+          #The type of appender (file or console).
+          - type: file
             #The path to the file to write access log to.
             currentLogFilename: ./server_access_log.txt
 
@@ -103,9 +106,11 @@ logging:
     loggers:
         foo: ERROR
         bar.baz: DEBUG
-    #The default log level - note that in previous versions rootLevel used to sit under file propety, this will throw an exception now if the config remains after updating to this version
-    rootLevel: INFO
-    file:
+    #The default log level - note that in previous versions this was called rootLevel and used to sit under file property, this will throw an exception now if the config remains after updating to this version
+    level: INFO
+    appenders:
+      #Logs to a file.
+      - type: file
         #The path to the file to write the server log to.
         currentLogFilename: ./server.log
         #The threshold over which log statements must be before being logged.
@@ -114,7 +119,8 @@ logging:
         timeZone: GMT+10
         # specify a log format for the file log 
         logFormat: "%-5p [%d{ISO8601,GMT+10}] [%-30thread] %c: %m%n%xEx"
-    console:
+      #Logs to the console.
+      - type: console
         # the timezone to print dates in (defaults to TimeZone.getDefault())
         timeZone: GMT+10
         # the threshold over which log statements must be before being logged.

--- a/src/java/grails/plugin/lightweightdeploy/logging/FilteredLoggingConfiguration.java
+++ b/src/java/grails/plugin/lightweightdeploy/logging/FilteredLoggingConfiguration.java
@@ -1,0 +1,71 @@
+package grails.plugin.lightweightdeploy.logging;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.unmodifiableSet;
+
+/**
+ * Extends the DropWizard-like log config to allow direction of certain log output to certain appenders.
+ * <p/>
+ * Wraps another appender and filters the log messages it receives.
+ * If 'includes' is specified, only logs on loggers whose name is in that comma-separated list will be allowed.
+ * If 'excludes' is specified, any logs on loggers whose name is in that comma-separated list will be excluded.
+ */
+public class FilteredLoggingConfiguration extends AbstractLoggingConfiguration {
+
+    private AbstractLoggingConfiguration appender;
+    private Set<String> inclusions = new HashSet<String>();
+    private Set<String> exclusions = new HashSet<String>();
+
+    public FilteredLoggingConfiguration(Map<String, ?> config) {
+        super(config);
+
+        if (config.containsKey("appender")) {
+            Map<String, ?> appenderConfig = (Map<String, ?>) config.get("appender");
+            setAppender(LoggingConfiguration.createAppenderConfiguration(appenderConfig));
+        } else {
+            throw new IllegalArgumentException("Must provide an 'appender' for a filtered appender");
+        }
+
+        if (config.containsKey("includes")) {
+            List<String> inclusions = (List<String>) config.get("includes");
+            for (String inclusion : inclusions) {
+                addInclusion(inclusion);
+            }
+        }
+        if (config.containsKey("excludes")) {
+            List<String> exclusions = (List<String>) config.get("excludes");
+            for (String exclusion : exclusions) {
+                addExclusion(exclusion);
+            }
+        }
+    }
+
+    public AbstractLoggingConfiguration getAppender() {
+        return appender;
+    }
+
+    public Set<String> getInclusions() {
+        return unmodifiableSet(inclusions);
+    }
+
+    public Set<String> getExclusions() {
+        return unmodifiableSet(exclusions);
+    }
+
+    public void setAppender(AbstractLoggingConfiguration appender) {
+        this.appender = appender;
+    }
+
+    public void addInclusion(String s) {
+        inclusions.add(s);
+    }
+
+    public void addExclusion(String s) {
+        exclusions.add(s);
+    }
+
+}

--- a/src/java/grails/plugin/lightweightdeploy/logging/LogbackFactory.java
+++ b/src/java/grails/plugin/lightweightdeploy/logging/LogbackFactory.java
@@ -13,6 +13,7 @@ import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
 import ch.qos.logback.core.spi.FilterAttachable;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -97,12 +98,15 @@ public class LogbackFactory {
 
     public static Set<OutputStreamAppender<ILoggingEvent>> buildAppenders(LoggingConfiguration configuration, LoggerContext context) {
         final Set<OutputStreamAppender<ILoggingEvent>> appenders = new HashSet<OutputStreamAppender<ILoggingEvent>>();
-        if (configuration.hasFileConfiguration()) {
-            appenders.add(buildFileAppender(configuration.getFileConfiguration(), context));
-        }
-        if (configuration.hasConsoleConfiguration()) {
-            appenders.add(buildConsoleAppender(configuration.getConsoleConfiguration(), context));
+        List<AbstractLoggingConfiguration> appenderConfigs = configuration.getAppenderConfigurations();
+        for (AbstractLoggingConfiguration appenderConfig : appenderConfigs) {
+            if (appenderConfig instanceof ConsoleLoggingConfiguration) {
+                appenders.add(buildConsoleAppender((ConsoleLoggingConfiguration) appenderConfig, context));
+            } else if (appenderConfig instanceof FileLoggingConfiguration) {
+                appenders.add(buildFileAppender((FileLoggingConfiguration) appenderConfig, context));
+            }
         }
         return appenders;
     }
+
 }

--- a/src/java/grails/plugin/lightweightdeploy/logging/LoggingConfiguration.java
+++ b/src/java/grails/plugin/lightweightdeploy/logging/LoggingConfiguration.java
@@ -57,12 +57,14 @@ public class LoggingConfiguration {
         return unmodifiableList(appenderConfigurations);
     }
 
-    private static AbstractLoggingConfiguration createAppenderConfiguration(Map<String, ?> appenderConfig) {
+    static AbstractLoggingConfiguration createAppenderConfiguration(Map<String, ?> appenderConfig) {
         String type = appenderConfig.get("type").toString();
         if (type.equals("file")) {
             return new FileLoggingConfiguration(appenderConfig);
         } else if (type.equals("console")) {
             return new ConsoleLoggingConfiguration(appenderConfig);
+        } else if (type.equals("filtered")) {
+            return new FilteredLoggingConfiguration(appenderConfig);
         } else {
             throw new IllegalArgumentException("Unknown appender type '" + type + "'");
         }

--- a/src/java/grails/plugin/lightweightdeploy/logging/LoggingConfiguration.java
+++ b/src/java/grails/plugin/lightweightdeploy/logging/LoggingConfiguration.java
@@ -68,42 +68,12 @@ public class LoggingConfiguration {
         }
     }
 
-    @Deprecated
-    public FileLoggingConfiguration getFileConfiguration() {
-        for (AbstractLoggingConfiguration appenderConfig : appenderConfigurations) {
-            if (appenderConfig instanceof FileLoggingConfiguration) {
-                return (FileLoggingConfiguration) appenderConfig;
-            }
-        }
-        return null;
-    }
-
-    @Deprecated
-    public ConsoleLoggingConfiguration getConsoleConfiguration() {
-        for (AbstractLoggingConfiguration appenderConfig : appenderConfigurations) {
-            if (appenderConfig instanceof ConsoleLoggingConfiguration) {
-                return (ConsoleLoggingConfiguration) appenderConfig;
-            }
-        }
-        return null;
-    }
-
     public Level getRootLevel() {
         return rootLevel;
     }
 
     public Map<String, Level> getLoggers() {
         return loggers;
-    }
-
-    @Deprecated
-    public boolean hasFileConfiguration() {
-        return getFileConfiguration() != null;
-    }
-
-    @Deprecated
-    public boolean hasConsoleConfiguration() {
-        return getConsoleConfiguration() != null;
     }
 
     public TimeZone getTimeZone() {

--- a/src/java/grails/plugin/lightweightdeploy/logging/LoggingConfiguration.java
+++ b/src/java/grails/plugin/lightweightdeploy/logging/LoggingConfiguration.java
@@ -1,44 +1,91 @@
 package grails.plugin.lightweightdeploy.logging;
 
 import ch.qos.logback.classic.Level;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
+import static java.util.Collections.unmodifiableList;
+
 public class LoggingConfiguration {
 
-    private FileLoggingConfiguration fileConfiguration;
-    private ConsoleLoggingConfiguration consoleConfiguration;
+    private static final Logger logger = LoggerFactory.getLogger(LoggingConfiguration.class);
+
+    private List<AbstractLoggingConfiguration> appenderConfigurations = new ArrayList<AbstractLoggingConfiguration>();
     private Level rootLevel = Level.INFO;
     private Map<String, Level> loggers = new HashMap<String, Level>();
 
     public LoggingConfiguration(Map<String, ?> config) {
-        if (config.containsKey("file")) {
-            Map<String, ?> fileConfig = (Map<String, ?>) config.get("file");
-            this.fileConfiguration = new FileLoggingConfiguration(fileConfig);
+        if (config.containsKey("level")) {
+            rootLevel = Level.toLevel(config.get("level").toString());
         }
-        if (config.containsKey("console")) {
-            Map<String, ?> consoleConfig = (Map<String, ?>) config.get("console");
-            this.consoleConfiguration = new ConsoleLoggingConfiguration(consoleConfig);
-        }
-        if (config.containsKey("rootLevel")) {
-            rootLevel = Level.toLevel(config.get("rootLevel").toString());
+        if (config.containsKey("appenders")) {
+            List<Map<String, ?>> appendersConfig = (List<Map<String, ?>>) config.get("appenders");
+            for (Map<String, ?> appenderConfig : appendersConfig) {
+                appenderConfigurations.add(createAppenderConfiguration(appenderConfig));
+            }
         }
         if (config.containsKey("loggers")) {
             for (Map.Entry<String, ?> entry : ((Map<String, ?>) config.get("loggers")).entrySet()) {
                 loggers.put(entry.getKey(), Level.toLevel(entry.getValue().toString()));
             }
         }
+
+        // handle deprecated logging format
+        if (config.containsKey("file")) {
+            logger.warn("'file' is deprecated - please move to 'appenders' list with type 'file'");
+            Map<String, ?> fileConfig = (Map<String, ?>) config.get("file");
+            appenderConfigurations.add(new FileLoggingConfiguration(fileConfig));
+        }
+        if (config.containsKey("console")) {
+            logger.warn("'console' is deprecated - please move to 'appenders' list with type 'console'");
+            Map<String, ?> consoleConfig = (Map<String, ?>) config.get("console");
+            appenderConfigurations.add(new ConsoleLoggingConfiguration(consoleConfig));
+        }
+        if (config.containsKey("rootLevel")) {
+            logger.warn("'rootLevel' is deprecated in favor of 'level'");
+            rootLevel = Level.toLevel(config.get("rootLevel").toString());
+        }
     }
 
+    public List<AbstractLoggingConfiguration> getAppenderConfigurations() {
+        return unmodifiableList(appenderConfigurations);
+    }
 
+    private static AbstractLoggingConfiguration createAppenderConfiguration(Map<String, ?> appenderConfig) {
+        String type = appenderConfig.get("type").toString();
+        if (type.equals("file")) {
+            return new FileLoggingConfiguration(appenderConfig);
+        } else if (type.equals("console")) {
+            return new ConsoleLoggingConfiguration(appenderConfig);
+        } else {
+            throw new IllegalArgumentException("Unknown appender type '" + type + "'");
+        }
+    }
+
+    @Deprecated
     public FileLoggingConfiguration getFileConfiguration() {
-        return fileConfiguration;
+        for (AbstractLoggingConfiguration appenderConfig : appenderConfigurations) {
+            if (appenderConfig instanceof FileLoggingConfiguration) {
+                return (FileLoggingConfiguration) appenderConfig;
+            }
+        }
+        return null;
     }
 
+    @Deprecated
     public ConsoleLoggingConfiguration getConsoleConfiguration() {
-        return consoleConfiguration;
+        for (AbstractLoggingConfiguration appenderConfig : appenderConfigurations) {
+            if (appenderConfig instanceof ConsoleLoggingConfiguration) {
+                return (ConsoleLoggingConfiguration) appenderConfig;
+            }
+        }
+        return null;
     }
 
     public Level getRootLevel() {
@@ -49,24 +96,21 @@ public class LoggingConfiguration {
         return loggers;
     }
 
+    @Deprecated
     public boolean hasFileConfiguration() {
-        return fileConfiguration != null;
+        return getFileConfiguration() != null;
     }
 
+    @Deprecated
     public boolean hasConsoleConfiguration() {
-        return consoleConfiguration != null;
+        return getConsoleConfiguration() != null;
     }
 
     public TimeZone getTimeZone() {
-
-        if (hasConsoleConfiguration()) {
-            return consoleConfiguration.getTimeZone();
-        } else if (hasFileConfiguration()) {
-            return fileConfiguration.getTimeZone();
+        if (!appenderConfigurations.isEmpty()) {
+            return appenderConfigurations.get(0).getTimeZone();
         }
-
         return TimeZone.getDefault();
-
     }
 
 }

--- a/test/unit/grails/plugin/lightweightdeploy/ConfigurationTest.groovy
+++ b/test/unit/grails/plugin/lightweightdeploy/ConfigurationTest.groovy
@@ -48,13 +48,13 @@ public class ConfigurationTest {
     @Test
     void serverConsoleLoggingThresholdShouldDefaultToAll() throws IOException {
         Map<String, ? extends Object> config = defaultConfig()
-        attachServerConsoleLoggingConfig(config).console.remove("threshold")
+        attachServerConsoleLoggingConfig(config).appenders[0].remove("threshold")
         Configuration configuration = new Configuration(config)
-        assertEquals(Level.ALL, configuration.serverLogConfiguration.consoleConfiguration.threshold)
+        assertEquals(Level.ALL, configuration.serverLogConfiguration.appenderConfigurations[0].threshold)
     }
 
     @Test
-    void ifServerLoggingConsoleSetInConfigThenFileLoggingShouldBeSetToTrue() throws IOException {
+    void ifServerLoggingConsoleSetInConfigThenServerLoggingShouldBeSetToTrue() throws IOException {
         Map<String, Map<String, Object>> config = defaultConfig()
         attachServerConsoleLoggingConfig(config)
         Configuration configuration = new Configuration(config)
@@ -66,16 +66,15 @@ public class ConfigurationTest {
         Map<String, Map<String, Object>> config = defaultConfig()
         attachServerConsoleLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals(Level.DEBUG, configuration.serverLogConfiguration.consoleConfiguration.threshold)
+        assertEquals(Level.DEBUG, configuration.serverLogConfiguration.appenderConfigurations[0].threshold)
     }
 
     @Test
     void serverConsoleLoggingTimezoneShouldDefaultToLocal() throws IOException {
         Map<String, Map<String, Object>> config = defaultConfig()
-        attachServerConsoleLoggingConfig(config)
-        config.logging.console.remove("timeZone")
+        attachServerConsoleLoggingConfig(config).appenders[0].remove("timeZone")
         Configuration configuration = new Configuration(config)
-        assertEquals(TimeZone.default, configuration.serverLogConfiguration.consoleConfiguration.timeZone)
+        assertEquals(TimeZone.default, configuration.serverLogConfiguration.appenderConfigurations[0].timeZone)
     }
 
     @Test
@@ -83,7 +82,7 @@ public class ConfigurationTest {
         Map<String, Map<String, Object>> config = defaultConfig()
         attachServerConsoleLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals(TimeZone.getTimeZone("GMT+10"), configuration.serverLogConfiguration.consoleConfiguration.timeZone)
+        assertEquals(TimeZone.getTimeZone("GMT+10"), configuration.serverLogConfiguration.appenderConfigurations[0].timeZone)
     }
 
     @Test
@@ -91,21 +90,21 @@ public class ConfigurationTest {
         Map<String, Map<String, Object>> config = defaultConfig()
         attachServerConsoleLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals("[%d{ISO8601}] %m%n", configuration.serverLogConfiguration.consoleConfiguration.logFormat.get())
+        assertEquals("[%d{ISO8601}] %m%n", configuration.serverLogConfiguration.appenderConfigurations[0].logFormat.get())
     }
 
     @Test
     void serverFileLoggingThresholdShouldDefaultToAll() throws IOException {
         Map<String, ? extends Object> config = defaultConfig()
-        attachServerFileLoggingConfig(config).file.remove("threshold")
+        attachServerFileLoggingConfig(config).appenders[0].remove("threshold")
         Configuration configuration = new Configuration(config)
-        assertEquals(Level.ALL, configuration.serverLogConfiguration.fileConfiguration.threshold)
+        assertEquals(Level.ALL, configuration.serverLogConfiguration.appenderConfigurations[0].threshold)
     }
 
     @Test
     void serverFileLoggingRootLevelShouldDefaultToInfo() throws IOException {
         Map<String, ? extends Object> config = defaultConfig()
-        attachServerFileLoggingConfig(config).remove("rootLevel")
+        attachServerFileLoggingConfig(config).remove("level")
         Configuration configuration = new Configuration(config)
         assertEquals(Level.INFO, configuration.serverLogConfiguration.rootLevel)
     }
@@ -130,7 +129,7 @@ public class ConfigurationTest {
     void serverFileLoggingShouldNotAcceptLoggersInsideFileConfiguration() {
         Map<String, ? extends Object> config = defaultConfig()
         attachServerFileLoggingConfig(config)
-        config.logging.file.put("loggers", config.logging.loggers)
+        config.logging.appenders[0].put("loggers", config.logging.loggers)
         new Configuration(config)
     }
 
@@ -138,12 +137,12 @@ public class ConfigurationTest {
     void serverFileLoggingShouldNotAcceptRootLevelInsideFileConfiguration() {
         Map<String, ? extends Object> config = defaultConfig()
         attachServerFileLoggingConfig(config)
-        config.logging.file.put("rootLevel", config.logging.rootLevel)
+        config.logging.appenders[0].put("rootLevel", config.logging.level)
         new Configuration(config)
     }
 
     @Test
-    void ifServerLoggingFileSetInConfigThenFileLoggingShouldBeSetToTrue() throws IOException {
+    void ifServerLoggingFileSetInConfigThenServerLoggingShouldBeSetToTrue() throws IOException {
         Map<String, Map<String, Object>> config = defaultConfig()
         attachServerFileLoggingConfig(config)
         Configuration configuration = new Configuration(config)
@@ -155,7 +154,7 @@ public class ConfigurationTest {
         Map<String, Map<String, Object>> config = defaultConfig()
         attachServerFileLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals(Level.DEBUG, configuration.serverLogConfiguration.fileConfiguration.threshold)
+        assertEquals(Level.DEBUG, configuration.serverLogConfiguration.appenderConfigurations[0].threshold)
     }
 
     @Test
@@ -180,16 +179,16 @@ public class ConfigurationTest {
         Map<String, Map<String, Object>> config = defaultConfig()
         attachServerFileLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals("/app/logs/server.log", configuration.serverLogConfiguration.fileConfiguration.currentLogFilename)
+        assertEquals("/app/logs/server.log",
+                configuration.serverLogConfiguration.appenderConfigurations[0].currentLogFilename)
     }
 
     @Test
     void serverFileLoggingTimezoneShouldDefaultToLocal() throws IOException {
         Map<String, Map<String, Object>> config = defaultConfig()
-        attachServerFileLoggingConfig(config)
-        config.logging.file.remove("timeZone")
+        attachServerFileLoggingConfig(config).appenders[0].remove("timeZone")
         Configuration configuration = new Configuration(config)
-        assertEquals(TimeZone.default, configuration.serverLogConfiguration.fileConfiguration.timeZone)
+        assertEquals(TimeZone.default, configuration.serverLogConfiguration.appenderConfigurations[0].timeZone)
     }
 
     @Test
@@ -197,7 +196,8 @@ public class ConfigurationTest {
         Map<String, Map<String, Object>> config = defaultConfig()
         attachServerFileLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals(TimeZone.getTimeZone("GMT+10"), configuration.serverLogConfiguration.fileConfiguration.timeZone)
+        assertEquals(TimeZone.getTimeZone("GMT+10"),
+                configuration.serverLogConfiguration.appenderConfigurations[0].timeZone)
     }
 
     @Test
@@ -205,15 +205,16 @@ public class ConfigurationTest {
         Map<String, Map<String, Object>> config = defaultConfig()
         attachServerFileLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals("[%d{ISO8601}] %m%n", configuration.serverLogConfiguration.fileConfiguration.logFormat.get())
+        assertEquals("[%d{ISO8601}] %m%n",
+                configuration.serverLogConfiguration.appenderConfigurations[0].logFormat.get())
     }
 
     @Test
     void requestLoggingThresholdShouldDefaultToAll() throws IOException {
         Map<String, ? extends Object> config = defaultConfig()
-        attachRequestLoggingConfig(config).file.remove("threshold")
+        attachRequestLoggingConfig(config).appenders[0].remove("threshold")
         Configuration configuration = new Configuration(config)
-        assertEquals(Level.ALL, configuration.requestLogConfiguration.fileConfiguration.threshold)
+        assertEquals(Level.ALL, configuration.requestLogConfiguration.appenderConfigurations[0].threshold)
     }
 
     @Test
@@ -225,11 +226,11 @@ public class ConfigurationTest {
     }
 
     @Test
-    void requestloggingThresholdShouldBeSetToValueInFile() throws IOException {
+    void requestLoggingThresholdShouldBeSetToValueInFile() throws IOException {
         Map<String, Map<String, Object>> config = defaultConfig()
         attachRequestLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals(Level.ALL, configuration.requestLogConfiguration.fileConfiguration.threshold)
+        assertEquals(Level.ALL, configuration.requestLogConfiguration.appenderConfigurations[0].threshold)
     }
 
     @Test
@@ -237,13 +238,14 @@ public class ConfigurationTest {
         Map<String, Map<String, Object>> config = defaultConfig()
         attachRequestLoggingConfig(config)
         Configuration configuration = new Configuration(config)
-        assertEquals("/app/logs/request.log", configuration.requestLogConfiguration.fileConfiguration.currentLogFilename)
+        assertEquals("/app/logs/request.log",
+                configuration.requestLogConfiguration.appenderConfigurations[0].currentLogFilename)
     }
 
     @Test
     void requestLoggingTimezoneShouldDefaultToLocal() throws IOException {
         Map<String, Map<String, Object>> config = defaultConfig()
-        attachRequestLoggingConfig(config).file.remove("timeZone")
+        attachRequestLoggingConfig(config).appenders[0].remove("timeZone")
         Configuration configuration = new Configuration(config)
         assertEquals(TimeZone.default, configuration.requestLogConfiguration.timeZone)
     }
@@ -254,6 +256,40 @@ public class ConfigurationTest {
         attachRequestLoggingConfig(config)
         Configuration configuration = new Configuration(config)
         assertEquals(TimeZone.getTimeZone("GMT+10"), configuration.requestLogConfiguration.timeZone)
+    }
+
+    @Test
+    public void deprecatedServerFileLoggingFormatSupported() throws Exception {
+        Map<String, Map<String, Object>> config = defaultConfig()
+        attachDeprecatedServerFileLoggingConfig(config)
+        Configuration configuration = new Configuration(config)
+        assertEquals(1, configuration.serverLogConfiguration.appenderConfigurations.size())
+    }
+
+    @Test
+    public void deprecatedServerConsoleLoggingFormatSupported() throws Exception {
+        Map<String, Map<String, Object>> config = defaultConfig()
+        attachDeprecatedServerConsoleLoggingConfig(config)
+        Configuration configuration = new Configuration(config)
+        assertEquals(1, configuration.serverLogConfiguration.appenderConfigurations.size())
+    }
+
+    @Test
+    public void deprecatedRequestLoggingFormatSupported() throws Exception {
+        Map<String, Map<String, Object>> config = defaultConfig()
+        attachDeprecatedRequestLoggingConfig(config)
+        Configuration configuration = new Configuration(config)
+        assertEquals(1, configuration.requestLogConfiguration.appenderConfigurations.size())
+    }
+
+    @Test
+    public void multipleLoggersOfSameTypeSupported() throws Exception {
+        Map<String, Map<String, Object>> config = defaultConfig()
+        attachServerFileLoggingConfig(config).appenders[0].currentLogFilename = '/app/logs/server-foo.log'
+        attachServerFileLoggingConfig(config).appenders[1].currentLogFilename = '/app/logs/server-bar.log'
+        Configuration configuration = new Configuration(config)
+        assertEquals(['/app/logs/server-foo.log', '/app/logs/server-bar.log'],
+                configuration.serverLogConfiguration.appenderConfigurations*.currentLogFilename)
     }
 
     @Test
@@ -348,7 +384,7 @@ public class ConfigurationTest {
         config.jmx
     }
 
-    protected def attachRequestLoggingConfig(def config) {
+    protected def attachDeprecatedRequestLoggingConfig(def config) {
         config.http.requestLog = [
                 file: [
                         threshold: Level.ALL.levelStr,
@@ -358,7 +394,20 @@ public class ConfigurationTest {
         config.http.requestLog
     }
 
-    protected Map<String, Object> attachServerFileLoggingConfig(Map<String, Map<String, Object>> config) {
+    protected def attachRequestLoggingConfig(def config) {
+        config.http.requestLog = [
+                appenders: [
+                        [
+                                type: "file",
+                                threshold: Level.ALL.levelStr,
+                                currentLogFilename: "/app/logs/request.log",
+                                timeZone: "GMT+10"
+                        ]
+                ]]
+        config.http.requestLog
+    }
+
+    protected Map<String, Object> attachDeprecatedServerFileLoggingConfig(Map<String, Map<String, Object>> config) {
         config.logging = [
                 rootLevel: Level.WARN.levelStr,
                 loggers: [
@@ -373,7 +422,7 @@ public class ConfigurationTest {
         config.logging
     }
 
-    protected Map<String, Object> attachServerConsoleLoggingConfig(Map<String, Map<String, Object>> config) {
+    protected Map<String, Object> attachDeprecatedServerConsoleLoggingConfig(Map<String, Map<String, Object>> config) {
         config.logging = [
                 rootLevel: Level.WARN.levelStr,
                 loggers: [
@@ -384,6 +433,45 @@ public class ConfigurationTest {
                         threshold: Level.DEBUG.levelStr,
                         timeZone: "GMT+10",
                         logFormat: "[%d{ISO8601}] %m%n"]]
+        config.logging
+    }
+
+    protected Map<String, Object> attachServerFileLoggingConfig(Map<String, Map<String, Object>> config) {
+        if (!config.logging) {
+            attachServerLoggingConfig(config)
+        }
+        config.logging.appenders += [
+                type: "file",
+                threshold: Level.DEBUG.levelStr,
+                currentLogFilename: "/app/logs/server.log",
+                logFormat: "[%d{ISO8601}] %m%n",
+                timeZone: "GMT+10"
+        ]
+        config.logging
+    }
+
+    protected Map<String, Object> attachServerConsoleLoggingConfig(Map<String, Map<String, Object>> config) {
+        if (!config.logging) {
+            attachServerLoggingConfig(config)
+        }
+        config.logging.appenders += [
+                type: "console",
+                threshold: Level.DEBUG.levelStr,
+                timeZone: "GMT+10",
+                logFormat: "[%d{ISO8601}] %m%n"
+        ]
+        config.logging
+    }
+
+    protected Map<String, Object> attachServerLoggingConfig(Map<String, Map<String, Object>> config) {
+        config.logging = [
+                level: Level.WARN.levelStr,
+                loggers: [
+                        "foo": Level.INFO.levelStr,
+                        "bar.baz": Level.ERROR.levelStr
+                ],
+                appenders: []
+        ]
         config.logging
     }
 


### PR DESCRIPTION
- Add support for the log config format introduced in [DropWizard 0.7.0](https://dropwizard.github.io/dropwizard/manual/core.html#id4), which will allow configuration of multiple loggers of the same type.
- Deprecate the existing log config format (backwards compatibility preserved).
- Add support for filtered appenders, which wrap another appender and limit the log messages it receives by logger name.
