### PR TITLE
Update to support gzip in same way as DropWizard (#38)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 /*.tmproj
 /ivy*
 /eclipse
+/.idea
+*.ipr
+*.iml
+*.iws
 
 # default HSQL database files for production mode
 /prodDb.*
@@ -40,5 +44,4 @@
 /target
 
 # other
-*.iws
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,27 @@ http:
           - type: file
             #The path to the file to write access log to.
             currentLogFilename: ./server_access_log.txt
+    gzip:
+        #If true, all requests with gzip in their Accept-Content-Encoding headers will have their response entities encoded with gzip.
+        enabled: true
+        #All response entities under this size are not compressed.
+        minimumEntitySize: 256
+        #The size of the buffer to use when compressing.
+        bufferSize: 8192
+        #The set of agents to exclude from compression.
+        #excludedUserAgents:
+        #If specified, the set of mime types to compress.
+        #compressedMimeTypes:
+        #If specified, compression will only be applied to these HTTP methods.  `GET` is always used, even if not specified.
+        #includedMethods:
+        #The set of agent patterns to exclude from compression.
+        #excludedUserAgentPatterns:
+        #If true, gzip-compatible deflation will be used.
+        gzipCompatibleDeflation: true
+        #The value of the Vary header sent with responses that could be compressed.
+        vary: Accept-Encoding
+        #The compression level used for deflate compression. (0-9).  See `java.util.zip.Deflater`.
+        deflateCompressionLevel: -1
 
 logging:
     #custom log levels - note that in previous versions loggers used to sit under file property, this will throw an exception now if the config remains after updating to this version 

--- a/src/java/grails/plugin/lightweightdeploy/connector/GzipConfiguration.java
+++ b/src/java/grails/plugin/lightweightdeploy/connector/GzipConfiguration.java
@@ -1,0 +1,104 @@
+package grails.plugin.lightweightdeploy.connector;
+
+import com.google.common.base.Function;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import org.eclipse.jetty.http.HttpHeaders;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.zip.Deflater;
+
+public class GzipConfiguration {
+
+    private boolean enabled = true;
+    private int minimumEntitySize = 256;
+    private int bufferSize = 8 * 1024;
+    private Set<String> excludedUserAgents;
+    private Set<String> compressedMimeTypes;
+    private Set<String> includedMethods;
+    private Set<Pattern> excludedUserAgentPatterns;
+    private boolean gzipCompatibleDeflation = true;
+    private String vary = HttpHeaders.ACCEPT_ENCODING;
+    private int deflateCompressionLevel = Deflater.DEFAULT_COMPRESSION;
+
+    public GzipConfiguration() { }
+
+    public GzipConfiguration(final Map<String, ?> gzipConfig) {
+        this.enabled = Objects.firstNonNull((Boolean) gzipConfig.get("enabled"), enabled);
+        this.minimumEntitySize = Objects.firstNonNull((Integer) gzipConfig.get("minimumEntitySize"), minimumEntitySize);
+        this.bufferSize = Objects.firstNonNull((Integer) gzipConfig.get("bufferSize"), bufferSize);
+        this.excludedUserAgents = Optional.fromNullable(extractConfiguredStringSet(gzipConfig, "excludedUserAgents")).or(Optional.fromNullable(excludedUserAgents)).orNull();
+        this.compressedMimeTypes = Optional.fromNullable(extractConfiguredStringSet(gzipConfig, "compressedMimeTypes")).or(Optional.fromNullable(compressedMimeTypes)).orNull();
+        this.includedMethods = Optional.fromNullable(extractConfiguredStringSet(gzipConfig, "includedMethods")).or(Optional.fromNullable(includedMethods)).orNull();
+        this.excludedUserAgentPatterns = Optional.fromNullable(extractConfiguredPatternSet(gzipConfig, "excludedUserAgentPatterns")).or(Optional.fromNullable(excludedUserAgentPatterns)).orNull();
+        this.gzipCompatibleDeflation = Objects.firstNonNull((Boolean) gzipConfig.get("gzipCompatibleDeflation"), gzipCompatibleDeflation);
+        this.vary = Objects.firstNonNull((String) gzipConfig.get("vary"), vary);
+        this.deflateCompressionLevel = Objects.firstNonNull((Integer) gzipConfig.get("deflateCompressionLevel"), deflateCompressionLevel);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> extractConfiguredStringList(final Map<String, ?> config, final String key) {
+        return (List<String>) config.get(key);
+    }
+
+    private Set<String> extractConfiguredStringSet(final Map<String, ?> config, final String key) {
+        List<String> values = extractConfiguredStringList(config, key);
+        return values == null ? null : ImmutableSet.copyOf(values);
+    }
+
+    private Set<Pattern> extractConfiguredPatternSet(final Map<String, ?> config, final String key) {
+        List<String> values = extractConfiguredStringList(config, key);
+        return values == null ? null : ImmutableSet.copyOf(Lists.transform(values, new Function<String, Pattern>() {
+            @Override
+            public Pattern apply(String input) {
+                return Pattern.compile(input);
+            }
+        }));
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public int getMinimumEntitySize() {
+        return minimumEntitySize;
+    }
+
+    public int getBufferSize() {
+        return bufferSize;
+    }
+
+    public int getDeflateCompressionLevel() {
+        return deflateCompressionLevel;
+    }
+
+    public String getVary() {
+        return vary;
+    }
+
+    public Set<String> getExcludedUserAgents() {
+        return excludedUserAgents;
+    }
+
+    public Set<String> getCompressedMimeTypes() {
+        return compressedMimeTypes;
+    }
+
+    public Set<String> getIncludedMethods() {
+        return includedMethods;
+    }
+
+    public Set<Pattern> getExcludedUserAgentPatterns() {
+        return excludedUserAgentPatterns;
+    }
+
+    public boolean isGzipCompatibleDeflation() {
+        return gzipCompatibleDeflation;
+    }
+
+}

--- a/src/java/grails/plugin/lightweightdeploy/connector/HttpConfiguration.java
+++ b/src/java/grails/plugin/lightweightdeploy/connector/HttpConfiguration.java
@@ -43,6 +43,8 @@ public class HttpConfiguration {
 
     private SslConfiguration sslConfiguration;
 
+    private GzipConfiguration gzipConfiguration = new GzipConfiguration();
+
     public HttpConfiguration(final Map<String, ?> httpConfig) throws IOException {
         this.port = (Integer) httpConfig.get("port");
 
@@ -69,6 +71,10 @@ public class HttpConfiguration {
         if (httpConfig.containsKey("ssl")) {
             Map<String, ?> sslConfig = (Map<String, ?>) httpConfig.get("ssl");
             this.sslConfiguration = new SslConfiguration(sslConfig);
+        }
+
+        if (httpConfig.containsKey("gzip")) {
+            this.gzipConfiguration = new GzipConfiguration((Map<String, ?>) httpConfig.get("gzip"));
         }
     }
 
@@ -154,6 +160,10 @@ public class HttpConfiguration {
 
     public SessionsConfiguration getSessionsConfiguration() {
         return sessionsConfiguration;
+    }
+
+    public GzipConfiguration getGzipConfiguration() {
+        return gzipConfiguration;
     }
 
 }

--- a/src/java/grails/plugin/lightweightdeploy/jetty/BiDiGzipFilter.java
+++ b/src/java/grails/plugin/lightweightdeploy/jetty/BiDiGzipFilter.java
@@ -1,0 +1,340 @@
+package grails.plugin.lightweightdeploy.jetty;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Sets;
+import org.eclipse.jetty.http.HttpHeaders;
+import org.eclipse.jetty.servlets.IncludableGzipFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterInputStream;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * An extension of {@link org.eclipse.jetty.servlets.IncludableGzipFilter} which decompresses gzip- and deflate-encoded request
+ * entities.
+ *
+ * This is pretty much the same as the equivalent class in DropWizard, with the exception that it introduces
+ * once-per-request handling.  This is necessary to prevent Grails includes/forwards from being processed.
+ */
+public class BiDiGzipFilter extends IncludableGzipFilter {
+
+    private final ThreadLocal<Deflater> localDeflater = new ThreadLocal<>();
+
+    public Set<String> getMimeTypes() {
+        return _mimeTypes;
+    }
+
+    public int getBufferSize() {
+        return _bufferSize;
+    }
+
+    public int getMinGzipSize() {
+        return _minGzipSize;
+    }
+
+    public int getDeflateCompressionLevel() {
+        return _deflateCompressionLevel;
+    }
+
+    public boolean isDeflateNoWrap() {
+        return _deflateNoWrap;
+    }
+
+    public Set<String> getMethods() {
+        return _methods;
+    }
+
+    public Set<String> getExcludedAgents() {
+        return _excludedAgents;
+    }
+
+    public Set<Pattern> getExcludedAgentPatterns() {
+        return _excludedAgentPatterns;
+    }
+
+    public Set<String> getExcludedPaths() {
+        return _excludedPaths;
+    }
+
+    public Set<Pattern> getExcludedPathPatterns() {
+        return _excludedPathPatterns;
+    }
+
+    public String getVary() {
+        return _vary;
+    }
+
+    public void setMimeTypes(Set<String> mimeTypes) {
+        if (_mimeTypes == null) {
+            _mimeTypes = Sets.newHashSet();
+        } else {
+            _mimeTypes.clear();
+        }
+        _mimeTypes.addAll(mimeTypes);
+    }
+
+    public void setBufferSize(int bufferSize) {
+        this._bufferSize = bufferSize;
+    }
+
+    public void setMinGzipSize(int minGzipSize) {
+        this._minGzipSize = minGzipSize;
+    }
+
+    public void setDeflateCompressionLevel(int level) {
+        this._deflateCompressionLevel = level;
+    }
+
+    public void setDeflateNoWrap(boolean noWrap) {
+        this._deflateNoWrap = noWrap;
+    }
+
+    public void setMethods(Set<String> methods) {
+        this._methods.clear();
+        this._methods.addAll(methods);
+    }
+
+    public void setExcludedAgents(Set<String> userAgents) {
+        this._excludedAgents = userAgents;
+    }
+
+    public void setExcludedAgentPatterns(Set<Pattern> userAgentPatterns) {
+        this._excludedAgentPatterns = userAgentPatterns;
+    }
+
+    public void setExcludedPaths(Set<String> paths) {
+        this._excludedPaths = paths;
+    }
+
+    public void setExcludedPathPatterns(Set<Pattern> patterns) {
+        this._excludedPathPatterns = patterns;
+    }
+
+    public void setVary(String vary) {
+        this._vary = vary;
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+        final HttpServletRequest request = (HttpServletRequest) req;
+        final String encoding = request.getHeader(HttpHeaders.CONTENT_ENCODING);
+        final String alreadyFilteredAttributeName = getClass().getName() + ".FILTERED";
+        if (request.getAttribute(alreadyFilteredAttributeName) != null) {
+            // Proceed without invoking this filter...
+            chain.doFilter(req, res);
+        } else {
+            // Do invoke this filter...
+            request.setAttribute(alreadyFilteredAttributeName, Boolean.TRUE);
+            try {
+                if (GZIP.equalsIgnoreCase(encoding)) {
+                    super.doFilter(wrapGzippedRequest(removeContentEncodingHeader(request)), res, chain);
+                } else if (DEFLATE.equalsIgnoreCase(encoding)) {
+                    super.doFilter(wrapDeflatedRequest(removeContentEncodingHeader(request)), res, chain);
+                } else {
+                    super.doFilter(req, res, chain);
+                }
+            } finally {
+                // Remove the "already filtered" request attribute for this request.
+                request.removeAttribute(alreadyFilteredAttributeName);
+            }
+        }
+    }
+
+    private Deflater buildDeflater() {
+        final Deflater deflater = localDeflater.get();
+        if (deflater != null) {
+            return deflater;
+        }
+        return new Deflater(_deflateCompressionLevel, _deflateNoWrap);
+    }
+
+    private ServletRequest wrapDeflatedRequest(HttpServletRequest request) throws IOException {
+        final Deflater deflater = buildDeflater();
+        final DeflaterInputStream input = new DeflaterInputStream(request.getInputStream(), deflater, _bufferSize) {
+            @Override
+            public void close() throws IOException {
+                deflater.reset();
+                localDeflater.set(deflater);
+                super.close();
+            }
+        };
+        return new WrappedServletRequest(request, input);
+    }
+
+    private ServletRequest wrapGzippedRequest(HttpServletRequest request) throws IOException {
+        return new WrappedServletRequest(request, new GZIPInputStream(request.getInputStream(), _bufferSize));
+    }
+
+    private HttpServletRequest removeContentEncodingHeader(final HttpServletRequest request) {
+        return new RemoveHttpHeaderWrapper(request, HttpHeaders.CONTENT_ENCODING);
+    }
+
+    private static class WrappedServletRequest extends HttpServletRequestWrapper {
+        private final ServletInputStream input;
+        private final BufferedReader reader;
+
+        private WrappedServletRequest(HttpServletRequest request,
+                                      InputStream inputStream) throws IOException {
+            super(request);
+            this.input = new WrappedServletInputStream(inputStream);
+            this.reader = new BufferedReader(new InputStreamReader(input, getCharset()));
+        }
+
+        private Charset getCharset() {
+            final String encoding = getCharacterEncoding();
+            if (encoding == null || !Charset.isSupported(encoding)) {
+                return Charsets.ISO_8859_1;
+            }
+            return Charset.forName(encoding);
+        }
+
+        @Override
+        public ServletInputStream getInputStream() throws IOException {
+            return input;
+        }
+
+        @Override
+        public BufferedReader getReader() throws IOException {
+            return reader;
+        }
+    }
+
+    private static class WrappedServletInputStream extends ServletInputStream {
+        private final InputStream input;
+
+        private WrappedServletInputStream(InputStream input) {
+            this.input = input;
+        }
+
+        @Override
+        public void close() throws IOException {
+            input.close();
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            return input.read(b, off, len);
+        }
+
+        @Override
+        public int available() throws IOException {
+            return input.available();
+        }
+
+        @Override
+        public void mark(int readlimit) {
+            input.mark(readlimit);
+        }
+
+        @Override
+        public boolean markSupported() {
+            return input.markSupported();
+        }
+
+        @Override
+        public int read() throws IOException {
+            return input.read();
+        }
+
+        @Override
+        public void reset() throws IOException {
+            input.reset();
+        }
+
+        @Override
+        public long skip(long n) throws IOException {
+            return input.skip(n);
+        }
+
+        @Override
+        public int read(byte[] b) throws IOException {
+            return input.read(b);
+        }
+    }
+
+    private static class RemoveHttpHeaderWrapper extends HttpServletRequestWrapper {
+        private final String headerName;
+
+        public RemoveHttpHeaderWrapper(final HttpServletRequest request, final String headerName) {
+            super(request);
+            this.headerName = headerName;
+        }
+
+        /**
+         * The default behavior of this method is to return
+         * getIntHeader(String name) on the wrapped request object.
+         *
+         * @param name a <code>String</code> specifying the name of a request header
+         */
+        @Override
+        public int getIntHeader(final String name) {
+            if (headerName.equalsIgnoreCase(name)) {
+                return -1;
+            } else {
+                return super.getIntHeader(name);
+            }
+        }
+
+        /**
+         * The default behavior of this method is to return getHeaders(String name)
+         * on the wrapped request object.
+         *
+         * @param name a <code>String</code> specifying the name of a request header
+         */
+        @Override
+        public Enumeration<String> getHeaders(final String name) {
+            if (headerName.equalsIgnoreCase(name)) {
+                return Collections.emptyEnumeration();
+            } else {
+                return super.getHeaders(name);
+            }
+        }
+
+        /**
+         * The default behavior of this method is to return getHeader(String name)
+         * on the wrapped request object.
+         *
+         * @param name a <code>String</code> specifying the name of a request header
+         */
+        @Override
+        public String getHeader(final String name) {
+            if (headerName.equalsIgnoreCase(name)) {
+                return null;
+            } else {
+                return super.getHeader(name);
+            }
+        }
+
+        /**
+         * The default behavior of this method is to return getDateHeader(String name)
+         * on the wrapped request object.
+         *
+         * @param name a <code>String</code> specifying the name of a request header
+         */
+        @Override
+        public long getDateHeader(final String name) {
+            if (headerName.equalsIgnoreCase(name)) {
+                return -1L;
+            } else {
+                return super.getDateHeader(name);
+            }
+        }
+    }
+
+}

--- a/test/unit/grails/plugin/lightweightdeploy/connector/GzipConfigurationTest.groovy
+++ b/test/unit/grails/plugin/lightweightdeploy/connector/GzipConfigurationTest.groovy
@@ -1,0 +1,144 @@
+package grails.plugin.lightweightdeploy.connector
+
+import com.google.common.collect.ImmutableSet
+import org.eclipse.jetty.http.HttpHeaders
+import org.eclipse.jetty.http.HttpMethods
+import org.junit.Test
+
+import java.util.zip.Deflater
+
+import static org.junit.Assert.*
+
+class GzipConfigurationTest {
+
+    GzipConfiguration defaultConfiguration = new GzipConfiguration()
+    GzipConfiguration nonDefaultConfiguration = new GzipConfiguration([
+            enabled: false,
+            minimumEntitySize: 1024,
+            bufferSize: 16 * 1024,
+            excludedUserAgents: [
+                    "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)",
+                    "Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.0 )",
+                    "Mozilla/4.0 (compatible; MSIE 5.5; Windows 98; Win 9x 4.90)"
+            ],
+            compressedMimeTypes: ["application/json", "application/xml"],
+            includedMethods: [HttpMethods.GET, HttpMethods.POST, HttpMethods.POST],
+            excludedUserAgentPatterns: [".*MSIE.*", ".*Opera.*"],
+            gzipCompatibleDeflation: false,
+            vary: "${HttpHeaders.ACCEPT_ENCODING}, ${HttpHeaders.ACCEPT_CHARSET}".toString(),
+            deflateCompressionLevel: Deflater.BEST_SPEED
+    ])
+
+    @Test
+    void enabledShouldDefault() {
+        assertTrue(defaultConfiguration.enabled)
+    }
+
+    @Test
+    void minimumEntitySizeShouldDefault() {
+        assertEquals(256, defaultConfiguration.minimumEntitySize)
+    }
+
+    @Test
+    void bufferSizeShouldDefault() {
+        assertEquals(8 * 1024, defaultConfiguration.bufferSize)
+    }
+
+    @Test
+    void excludedUserAgentsShouldDefault() {
+        assertNull(defaultConfiguration.excludedUserAgents)
+    }
+
+    @Test
+    void compressedMimeTypesShouldDefault() {
+        assertNull(defaultConfiguration.compressedMimeTypes)
+    }
+
+    @Test
+    void includedMethodShouldDefault() {
+        assertNull(defaultConfiguration.includedMethods)
+    }
+
+    @Test
+    void excludedUserAgentPatternsShouldDefault() {
+        assertNull(defaultConfiguration.excludedUserAgentPatterns)
+    }
+
+    @Test
+    void gzipCompatibleDeflationShouldDefault() {
+        assertTrue(defaultConfiguration.gzipCompatibleDeflation)
+    }
+
+    @Test
+    void varyShouldDefault() {
+        assertEquals(HttpHeaders.ACCEPT_ENCODING, defaultConfiguration.vary)
+    }
+
+    @Test
+    void deflateCompressionLevelShouldDefault() {
+        assertEquals(Deflater.DEFAULT_COMPRESSION, defaultConfiguration.deflateCompressionLevel)
+    }
+
+    @Test
+    void shouldSetEnabledFromConfig() {
+        assertFalse(nonDefaultConfiguration.enabled)
+    }
+
+    @Test
+    void shouldSetMinimumEntitySizeFromConfig() {
+        assertEquals(1024, nonDefaultConfiguration.minimumEntitySize)
+    }
+
+    @Test
+    void shouldSetBufferSizeFromConfig() {
+        assertEquals(16 * 1024, nonDefaultConfiguration.bufferSize)
+    }
+
+    @Test
+    void shouldSetExcludedUserAgentsFromConfig() {
+        assertEquals(
+                ImmutableSet.of("Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)", "Mozilla/4.0 (compatible; MSIE 5.5; Windows NT 5.0 )", "Mozilla/4.0 (compatible; MSIE 5.5; Windows 98; Win 9x 4.90)"),
+                nonDefaultConfiguration.excludedUserAgents
+        )
+    }
+
+    @Test
+    void shouldSetCompressedMimeTypesFromConfig() {
+        assertEquals(
+                ImmutableSet.of("application/json", "application/xml"),
+                nonDefaultConfiguration.compressedMimeTypes
+        )
+    }
+
+    @Test
+    void shouldSetIncludedMethodsFromConfig() {
+        assertEquals(
+                ImmutableSet.of(HttpMethods.GET, HttpMethods.POST, HttpMethods.POST),
+                nonDefaultConfiguration.includedMethods
+        )
+    }
+
+    @Test
+    void shouldSetExcludedUserAgentPatternsFromConfig() {
+        assertEquals(
+                [".*MSIE.*", ".*Opera.*"],
+                nonDefaultConfiguration.excludedUserAgentPatterns*.pattern().sort()
+        )
+    }
+
+    @Test
+    void shouldSetGzipCompatibleDeflactionFromConfig() {
+        assertFalse(nonDefaultConfiguration.gzipCompatibleDeflation)
+    }
+
+    @Test
+    void shouldSetVaryFromConfig() {
+        assertEquals("${HttpHeaders.ACCEPT_ENCODING}, ${HttpHeaders.ACCEPT_CHARSET}".toString(), nonDefaultConfiguration.vary)
+    }
+
+    @Test
+    void shouldSetDeflateCompressionLevelFromConfig() {
+        assertEquals(Deflater.BEST_SPEED, nonDefaultConfiguration.deflateCompressionLevel)
+    }
+
+}

--- a/test/unit/grails/plugin/lightweightdeploy/connector/HttpConfigurationTest.groovy
+++ b/test/unit/grails/plugin/lightweightdeploy/connector/HttpConfigurationTest.groovy
@@ -89,6 +89,13 @@ public class HttpConfigurationTest {
         assertEquals("workerName", configuration.sessionsConfiguration.workerName);
     }
 
+    @Test
+    void shouldAssumeGzipIfNoGzipBlock() {
+        Map<String, ? extends Object> config = defaultConfig()
+        HttpConfiguration configuration = new HttpConfiguration(config)
+        assertTrue(configuration.getGzipConfiguration().isEnabled())
+    }
+
     protected Map<String, Map<String, Object>> defaultConfig() {
         [port: 1234,
                 ssl: [keyStore: "/etc/pki/tls/jks/test.jks",


### PR DESCRIPTION
This adds a number of new configuration settings, with the leaf keys matching the ones used by DropWizard. The new configuration settings are documented in the README.

In particular, this adds support for decompressing gzip-encoded request bodies (by way of the BiDiGzipFilter). The default mime type handling has changed; instead of defaulting to only compressing a particular list of mime types, the new default behavior is to compress all non-gzip mime types (matching the default behavior of Jetty's GzipFilter).

The old list was:
"application/json", "application/xml", "text/html", "text/plain", "application/javascript",
"application/x-javascript", "text/javascript", "text/css", "text/xml", "image/svg+xml"
