### PR TITLE
Restrict internal servlets to only the internal connectors (#30)

### DIFF
--- a/src/java/grails/plugin/lightweightdeploy/ConnectorNameFunction.java
+++ b/src/java/grails/plugin/lightweightdeploy/ConnectorNameFunction.java
@@ -1,0 +1,13 @@
+package grails.plugin.lightweightdeploy;
+
+import com.google.common.base.Function;
+import org.eclipse.jetty.server.Connector;
+
+enum ConnectorNameFunction implements Function<Connector, String> {
+    INSTANCE; // enum singleton pattern
+
+    @Override
+    public String apply(Connector input) {
+        return input.getName();
+    }
+}


### PR DESCRIPTION
Previously, both the internal and external contexts were setting the handler's connector names to all existing connectors. This resulted in the intended behavior for the external servlets, as at that point, only the external connectors exist. However, at the point where the internal servlets are configured, both the internal and external connectors exist, resulting in the internal servlets being accessible on the external connectors.

This commit fixes the problem by explicitly controlling which connectors the internal/external contexts are applied to. This approach breaks compatibility with applications that have a custom Launcher that overrides createInternalContext/createExternalContext by adding a new parameter.
