### PR TITLE
Add support for specifying the external context path (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ http:
     port: 8080
     #A secondary port which will serve your administrative content. This should be firewalled off from external access. Check http://localhost:8048/ for what it provides.
     adminPort: 8048
+    #The context path at which to run the application.  By default, the application will be run at the root context.
+    contextPath: /
     #The minimum number of threads to keep active to serve requests
     minThreads: 8
     #The maximum number of threads to keep active to serve requests

--- a/src/java/grails/plugin/lightweightdeploy/ExternalContext.java
+++ b/src/java/grails/plugin/lightweightdeploy/ExternalContext.java
@@ -28,8 +28,9 @@ public class ExternalContext extends WebAppContext {
 
     public ExternalContext(String webAppRoot,
                            MetricRegistry metricsRegistry,
-                           HealthCheckRegistry healthCheckRegistry) throws IOException {
-        super(webAppRoot, "/");
+                           HealthCheckRegistry healthCheckRegistry,
+                           String contextPath) throws IOException {
+        super(webAppRoot, contextPath);
 
         setAttribute(METRICS_REGISTRY_SERVLET_ATTRIBUTE, metricsRegistry);
         setAttribute(HEALTH_CHECK_REGISTRY_SERVLET_ATTRIBUTE, healthCheckRegistry);

--- a/src/java/grails/plugin/lightweightdeploy/Launcher.java
+++ b/src/java/grails/plugin/lightweightdeploy/Launcher.java
@@ -14,6 +14,7 @@ import com.codahale.metrics.servlets.AdminServlet;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import grails.plugin.lightweightdeploy.connector.ExternalConnectorFactory;
+import grails.plugin.lightweightdeploy.connector.HttpConfiguration;
 import grails.plugin.lightweightdeploy.connector.InternalConnectorFactory;
 import grails.plugin.lightweightdeploy.connector.SessionsConfiguration;
 import grails.plugin.lightweightdeploy.jmx.JmxServer;
@@ -174,12 +175,13 @@ public class Launcher {
     protected Handler configureExternal(Server server, War war) throws IOException {
         logger.info("Configuring external connector(s)");
 
-        final ExternalConnectorFactory connectorFactory = new ExternalConnectorFactory(configuration.getHttpConfiguration(), metricsRegistry);
+        final HttpConfiguration httpConfiguration = configuration.getHttpConfiguration();
+        final ExternalConnectorFactory connectorFactory = new ExternalConnectorFactory(httpConfiguration, metricsRegistry);
         for (AbstractConnector externalConnector : connectorFactory.build()) {
             server.addConnector(externalConnector);
         }
 
-        return createExternalContext(server, war.getDirectory().getPath() + "/" + WAR_EXPLODED_SUBDIR);
+        return createExternalContext(server, war.getDirectory().getPath() + "/" + WAR_EXPLODED_SUBDIR, httpConfiguration.getContextPath());
     }
 
     protected Handler configureInternal(Server server) {
@@ -218,8 +220,8 @@ public class Launcher {
         handler.addServlet(new ServletHolder(new AdminServlet()), "/*");
     }
 
-    protected Handler createExternalContext(Server server, String webAppRoot) throws IOException {
-        final WebAppContext handler = new ExternalContext(webAppRoot, getMetricsRegistry(), getHealthCheckRegistry());
+    protected Handler createExternalContext(Server server, String webAppRoot, String contextPath) throws IOException {
+        final WebAppContext handler = new ExternalContext(webAppRoot, getMetricsRegistry(), getHealthCheckRegistry(), contextPath);
 
         // Enable sessions support if required
         final SessionsConfiguration sessionsConfiguration = configuration.getHttpConfiguration().getSessionsConfiguration();

--- a/src/java/grails/plugin/lightweightdeploy/connector/HttpConfiguration.java
+++ b/src/java/grails/plugin/lightweightdeploy/connector/HttpConfiguration.java
@@ -11,6 +11,8 @@ public class HttpConfiguration {
 
     private int adminPort = 8081;
 
+    private String contextPath = "/";
+
     private int minThreads = 8;
 
     private int maxThreads = 128;
@@ -44,9 +46,9 @@ public class HttpConfiguration {
     private SslConfiguration sslConfiguration;
 
     public HttpConfiguration(final Map<String, ?> httpConfig) throws IOException {
-        this.port = (Integer) httpConfig.get("port");
-
+        this.port = Objects.firstNonNull((Integer) httpConfig.get("port"), port);
         this.adminPort = Objects.firstNonNull((Integer) httpConfig.get("adminPort"), adminPort);
+        this.contextPath = Objects.firstNonNull((String) httpConfig.get("contextPath"), contextPath);
         this.minThreads = Objects.firstNonNull((Integer) httpConfig.get("minThreads"), minThreads);
         this.maxThreads = Objects.firstNonNull((Integer) httpConfig.get("maxThreads"), maxThreads);
         this.maxIdleTime = Objects.firstNonNull((Integer) httpConfig.get("maxIdleTime"), maxIdleTime);
@@ -78,6 +80,10 @@ public class HttpConfiguration {
 
     public Integer getAdminPort() {
         return adminPort;
+    }
+
+    public String getContextPath() {
+        return contextPath;
     }
 
     public int getMinThreads() {

--- a/test/unit/grails/plugin/lightweightdeploy/ExternalContextTest.groovy
+++ b/test/unit/grails/plugin/lightweightdeploy/ExternalContextTest.groovy
@@ -39,6 +39,11 @@ class ExternalContextTest {
     }
 
     @Test
+    void contextPathShouldBeSet() {
+        assertEquals("/app", externalContext.contextPath)
+    }
+
+    @Test
     void parentClassLoaderShouldBeUsedFirstToPreserveLogbackSettings() {
         assertTrue(externalContext.parentLoaderPriority)
     }
@@ -59,6 +64,6 @@ class ExternalContextTest {
     }
 
     private ExternalContext getExternalContext() {
-        new ExternalContext(".", new MetricRegistry(), new HealthCheckRegistry())
+        new ExternalContext(".", new MetricRegistry(), new HealthCheckRegistry(), "/app")
     }
 }

--- a/test/unit/grails/plugin/lightweightdeploy/connector/HttpConfigurationTest.groovy
+++ b/test/unit/grails/plugin/lightweightdeploy/connector/HttpConfigurationTest.groovy
@@ -89,6 +89,20 @@ public class HttpConfigurationTest {
         assertEquals("workerName", configuration.sessionsConfiguration.workerName);
     }
 
+    @Test
+    void contextPathShouldDefaultToRoot() {
+        HttpConfiguration configuration = new HttpConfiguration(defaultConfig())
+        assertEquals("/", configuration.getContextPath())
+    }
+
+    @Test
+    void contextPathShouldBeSetIfPresent() {
+        Map<String, ? extends Object> config = defaultConfig()
+        config.contextPath = "/app"
+        HttpConfiguration configuration = new HttpConfiguration(config)
+        assertEquals("/app", configuration.contextPath)
+    }
+
     protected Map<String, Map<String, Object>> defaultConfig() {
         [port: 1234,
                 ssl: [keyStore: "/etc/pki/tls/jks/test.jks",


### PR DESCRIPTION
Instead of hardcoding a context path of "/", allow specifying it in configuration as http.contextPath.

This change adds new arguments to Launcher.createExternalContext and ExternalContext's constructor, breaking compatibility with some existing applications.
