### PR TITLE
Fix HealthCheckUtil/MetricsUtil's support for environments other than test and production (#31)

### DIFF
--- a/src/groovy/grails/plugin/lightweightdeploy/application/healthcheck/HealthCheckUtil.groovy
+++ b/src/groovy/grails/plugin/lightweightdeploy/application/healthcheck/HealthCheckUtil.groovy
@@ -7,28 +7,32 @@ import org.codehaus.groovy.grails.web.context.ServletContextHolder
 
 class HealthCheckUtil {
 
-    /**
-     * The HealthCheckRegistry to use when Environment == TEST
-     */
-    private static HealthCheckRegistry testHealthCheckRegistry = null
+    private static HealthCheckRegistry fallbackHealthCheckRegistry = null
 
     private HealthCheckUtil() {
     }
 
     public static HealthCheckRegistry getHealthCheckRegistry() {
-        return getHealthCheckRegistry(Environment.getCurrent())
+        return servletHealthCheckRegistry ?: getFallbackHealthCheckRegistry()
     }
 
+    /**
+     * @deprecated use {@link #getHealthCheckRegistry()} instead
+     */
+    @Deprecated
     public static HealthCheckRegistry getHealthCheckRegistry(Environment environment) {
-        if (Environment.PRODUCTION.equals(environment)) {
-            return (HealthCheckRegistry) ServletContextHolder.servletContext.getAttribute(ExternalContext.HEALTH_CHECK_REGISTRY_SERVLET_ATTRIBUTE)
-        } else {
-            //Not all test types properly bootstrap the servletContext as of Grails 2.2.3. Therefore, in test mode, use
-            //a consistent instance
-            if (!testHealthCheckRegistry) {
-                testHealthCheckRegistry = new HealthCheckRegistry()
-            }
-            return testHealthCheckRegistry
-        }
+        return healthCheckRegistry
     }
+
+    private static getServletHealthCheckRegistry() {
+        return (HealthCheckRegistry) ServletContextHolder.servletContext?.getAttribute(ExternalContext.HEALTH_CHECK_REGISTRY_SERVLET_ATTRIBUTE)
+    }
+
+    private synchronized static getFallbackHealthCheckRegistry() {
+        if (!fallbackHealthCheckRegistry) {
+            fallbackHealthCheckRegistry = new HealthCheckRegistry()
+        }
+        return fallbackHealthCheckRegistry
+    }
+
 }

--- a/src/groovy/grails/plugin/lightweightdeploy/application/metrics/MetricsUtil.groovy
+++ b/src/groovy/grails/plugin/lightweightdeploy/application/metrics/MetricsUtil.groovy
@@ -7,28 +7,32 @@ import org.codehaus.groovy.grails.web.context.ServletContextHolder
 
 class MetricsUtil {
 
-    /**
-     * The MetricRegistry to use when Environment == TEST
-     */
-    private static MetricRegistry testMetricRegistry = null
+    private static MetricRegistry fallbackMetricRegistry = null
 
     private MetricsUtil() {
     }
 
     public static MetricRegistry getMetricRegistry() {
-        return getMetricRegistry(Environment.getCurrent())
+        return servletMetricRegistry ?: getFallbackMetricRegistry()
     }
 
+    /**
+     * @deprecated use {@link #getMetricRegistry()} instead
+     */
+    @Deprecated
     public static MetricRegistry getMetricRegistry(Environment environment) {
-        if (Environment.PRODUCTION.equals(environment)) {
-            return (MetricRegistry) ServletContextHolder.servletContext.getAttribute(ExternalContext.METRICS_REGISTRY_SERVLET_ATTRIBUTE)
-        } else {
-            //Not all test types properly bootstrap the servletContext as of Grails 2.2.3. Therefore, in test mode, use
-            //a consistent instance
-            if (!testMetricRegistry) {
-                testMetricRegistry = new MetricRegistry()
-            }
-            return testMetricRegistry
-        }
+        return metricRegistry
     }
+
+    private static MetricRegistry getServletMetricRegistry() {
+        return (MetricRegistry) ServletContextHolder.servletContext?.getAttribute(ExternalContext.METRICS_REGISTRY_SERVLET_ATTRIBUTE)
+    }
+
+    private synchronized static getFallbackMetricRegistry() {
+        if (!fallbackMetricRegistry) {
+            fallbackMetricRegistry = new MetricRegistry()
+        }
+        return fallbackMetricRegistry
+    }
+
 }


### PR DESCRIPTION
The logic is no longer environment-specific (the environment-specific signatures have been deprecated, and delegate to the default one). In all cases, if there is a registry in the servlet context, it is used.  If not, a fallback registry is instantiated on first access and then used. This supports all cases where the application is running with a properly initialized servlet context, as well as cases (such as testing) where the servlet context is not available.

I've tested the behavior with unit tests, integration tests, dev lightweight and prod lightweight, in Grails versions 2.2.3 and 2.4.3.
